### PR TITLE
Bugfix/ #117 + #122 + #127 query w/ shared DEs, ECONNRESET during caching + bad cli output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Accenture SFMC DevTools follows [semantic versioning](https://semver.org/).
 
 **Bugfixes:**
 
-- [#117](https://github.com/Accenture/sfmc-devtools/issues/117) queries not deployable when target is shared DE
+- [#117](https://github.com/Accenture/sfmc-devtools/issues/117) queries not deployable when target is shared
+- [#122](https://github.com/Accenture/sfmc-devtools/issues/122) ECONNRESET on caching metadata during deploy
+- [#127](https://github.com/Accenture/sfmc-devtools/issues/127) bad message "info: updated automation: undefined"
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Accenture SFMC DevTools follows [semantic versioning](https://semver.org/).
 
 ---
 
+## [3.1.0](https://github.com/Accenture/sfmc-devtools/compare/v3.0.3...v3.1.0) - 2021-??-??
+
+**Bugfixes:**
+
+- [#117](https://github.com/Accenture/sfmc-devtools/issues/117) queries not deployable when target is shared DE
+
+---
+
 ## [3.0.3](https://github.com/Accenture/sfmc-devtools/compare/v3.0.2...v3.0.3) - 2021-08-11
 
 **Bugfixes:**

--- a/lib/Deployer.js
+++ b/lib/Deployer.js
@@ -81,7 +81,10 @@ class Deployer {
             MetadataTypeInfo[type].client = this.client;
             MetadataTypeInfo[type].properties = this.properties;
             Util.logger.info('Caching dependent Metadata: ' + metadataType);
-            const result = await MetadataTypeInfo[type].retrieveForCache(this.buObject, subType);
+            let result;
+            await Util.retryOnError(`Retrying ${type}`, async () => {
+                result = await MetadataTypeInfo[type].retrieveForCache(this.buObject, subType);
+            });
             this.cache[type] = result.metadata;
         }
         // deploy metadata files, extending cache once deploys

--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -389,6 +389,8 @@ class DataExtension extends MetadataType {
 
             // revert client to current default
             this.client = clientBackup;
+            Folder.client = clientBackup;
+            Folder.cache = this.cache;
 
             // make sure to overwrite parent bu DEs with local ones
             metadata = { ...metadataParentBu, ...metadata };

--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -3,6 +3,7 @@
 const jsonToTable = require('json-to-table');
 const MetadataType = require('./MetadataType');
 const DataExtensionField = require('./DataExtensionField');
+const Folder = require('./Folder');
 const Util = require('../util/util');
 const File = require('../util/file');
 
@@ -336,9 +337,7 @@ class DataExtension extends MetadataType {
                 clientSecret: this.properties.credentials[buObject.credential].clientSecret,
                 tenant: this.properties.credentials[buObject.credential].tenant,
                 eid: this.properties.credentials[buObject.credential].eid,
-                mid: this.properties.credentials[buObject.credential].businessUnits[
-                    Util.parentBuName
-                ],
+                mid: this.properties.credentials[buObject.credential].eid,
                 businessUnit: Util.parentBuName,
                 credential: buObject.credential,
             };
@@ -351,6 +350,16 @@ class DataExtension extends MetadataType {
             }
             const metadataParentBu = await this._retrieveAll(additionalFields);
 
+            // get shared folders to match our shared / synched Data Extensions
+            Util.logger.info('- Caching dependent Metadata: folder (shared via _ParentBU_)');
+            Folder.cache = {};
+            Folder.client = this.client;
+            Folder.properties = this.properties;
+            const result = await Folder.retrieveForCache(buObjectParentBu);
+            const parentCache = {
+                folder: result.metadata,
+            };
+
             // get the types and clean out non-shared ones
             const folderTypesFromParent = require('../MetadataTypeDefinitions').folder
                 .folderTypesFromParent;
@@ -358,16 +367,22 @@ class DataExtension extends MetadataType {
                 try {
                     // get the data extension type from the folder
                     const folderContentType = Util.getFromCache(
-                        this.cache,
+                        parentCache,
                         'folder',
                         metadataParentBu[metadataEntry].CategoryID,
                         'ID',
                         'ContentType'
                     );
                     if (!folderTypesFromParent.includes(folderContentType)) {
+                        Util.logger.verbose(
+                            `removing ${metadataEntry} because r__folder_ContentType '${folderContentType}' identifies this DE as not being shared`
+                        );
                         delete metadataParentBu[metadataEntry];
                     }
                 } catch (ex) {
+                    Util.logger.debug(
+                        `removing ${metadataEntry} because of error while retrieving r__folder_ContentType: ${ex.message}`
+                    );
                     delete metadataParentBu[metadataEntry];
                 }
             }

--- a/lib/metadataTypes/MetadataType.js
+++ b/lib/metadataTypes/MetadataType.js
@@ -304,9 +304,10 @@ class MetadataType {
                         });
                     } else if (this.cache[this.definition.type][normalizedKey]) {
                         // normal way of processing update files
-                        metadata[metadataKey][this.definition.idField] = this.cache[
-                            this.definition.type
-                        ][normalizedKey][this.definition.idField];
+                        metadata[metadataKey][this.definition.idField] =
+                            this.cache[this.definition.type][normalizedKey][
+                                this.definition.idField
+                            ];
                         metadataToUpdate.push({
                             before: this.cache[this.definition.type][normalizedKey],
                             after: metadata[metadataKey],
@@ -474,8 +475,12 @@ class MetadataType {
                 async () => (response = await this.client.RestClient.patch(options))
             );
             this.checkForErrors(response);
+            // some times, e.g. automation dont return a key in their update response and hence we need to fall back to name
             Util.logger.info(
-                `- updated ${this.definition.type}: ${metadataEntry[this.definition.keyField]}`
+                `- updated ${this.definition.type}: ${
+                    metadataEntry[this.definition.keyField] ||
+                    metadataEntry[this.definition.nameField]
+                }`
             );
             return response;
         } catch (ex) {


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? 

- [x] Bug fix

## What changes did you make? (Give an overview)

- fixes #117 queries not deployable when target is shared DE
- fixes #122 ECONNRESET on caching metadata during deploy
- fixes #127 info: updated automation: undefined

because we are not necessarily caching folders before we cache data extensions when deploying queries - AND we are at the moment removing folders from cache that are not belonging to the current MID, queries that aim to write into shared DEs cant find the target DE's object ID and were blocked from deployment.
I used the already existing cache from parent logic for Dataextensions and added parent cache for folders inside of it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
- [x] README.md updated (if applicable)
- [x] CHANGELOG.md updated
- [x] ran `npm run docs` to update developer docs
