### PR TITLE
Bugfix/Keep going in case of failure retrieving DE fields

### DIFF
--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -313,7 +313,12 @@ class DataExtension extends MetadataType {
             // add fields to corresponding DE
             fieldKeys.forEach((key) => {
                 const field = fieldsObj[key];
-                metadata[field.DataExtension.CustomerKey].Fields.push(field);
+                if(metadata[field?.DataExtension?.CustomerKey]) {
+                    metadata[field.DataExtension.CustomerKey].Fields.push(field);
+                }
+                else {
+                    Util.logger.warn(`Issue retrieving data extension fields. key='${key}'`);
+                }
             });
 
             // sort fields by Ordinal value (API returns field unsorted)


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

_Please delete options that are not relevant._

- [x ] Bug fix

Added a condition in lib/metadataTypes/DataExtension.js:retrieve to skip over fields with invalid metadata.
Added feedback in the log to inform the user about the corrupted DE.

Problems arose when, for example, a DE has no CategoryID at all, that interrupt the whole DE retrieval process.
...

Please confirm that this does not created any unwanted side-effects.

...

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
- [ ] README.md updated (if applicable)
- [ ] CHANGELOG.md updated
- [ ] ran `npm run docs` to update developer docs
