### PR TITLE
#185 - Fix "this._setLoggingLevel is not a function" bug when running mcdev createDeltaPkg

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -260,7 +260,10 @@ yargs
                         'Disable templating & instead filter by the specified file path (comma separated)',
                 });
         },
-        handler: Mcdev.createDeltaPkg,
+        handler: (argv) => {
+            Mcdev._setLoggingLevel(argv);
+            Mcdev.createDeltaPkg(argv);
+        },
     })
     .command({
         command: 'upgrade',

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,6 @@ class Mcdev {
     * @returns {void}
     */
     static async createDeltaPkg(argv) {
-        this._setLoggingLevel(argv);
         properties = properties || File.loadConfigFile();
         if (!Util.checkProperties(properties)) {
             return null;


### PR DESCRIPTION
When createDeltaPkg (index.js) is called from cli.js, 'this' is not an instance of Mcdev hence the error that it can't find _setLoggingLevel.

I've updated the cli.js to call using an arrow function like the other commands. I've also removed the call to _setLoggingLevel from createDeltaPkg, technically this should work now (since the arrow function won't bind this) but I think it makes sense for consistency with the other commands to have the logging level set in the cli configuration.

Please review this change to make sure it makes sense. Whilst I'm confident in the fix, I have only read these two files so have a very limited understanding of the application.

Full error when running 'mcdev createDeltaPkg range Credential/BU' is as follows:

mcdev createDeltaPkg [range] [filter]

Copies commit-based file delta into deploy folder

Positionals:
  range   Pull Request target branch or git commit range                                                                                                                                                       [string]
  filter  Disable templating & instead filter by the specified file path (comma separated)                                                                                                                     [string]

Options:
      --version                 Show version number                                                                                                                                                           [boolean]
      --verbose                 Run with verbose CLI output                                                                                                                                                   [boolean]
      --debug                   Enable developer & edge-case features                                                                                                                                         [boolean]
      --silent                  Only output errors to CLI                                                                                                                                                     [boolean]
  -y, --skipInteraction, --yes  Interactive questions where possible and go with defaults instead
      --help                    Show help                                                                                                                                                                     [boolean]

TypeError: this._setLoggingLevel is not a function
    at Object.createDeltaPkg [as handler] (/usr/local/lib/node_modules/mcdev/lib/index.js:32:14)
    at /usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:9052
    at j (/usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:4931)
    at M.applyMiddlewareAndGetResult (/usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:9021)
    at M.runCommand (/usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:7206)
    at Jt.[runYargsParserAndExecuteCommands] (/usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:55997)
    at Jt.parse (/usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:38250)
    at Jt.get [as argv] (/usr/local/lib/node_modules/mcdev/node_modules/yargs/build/index.cjs:1:59486)
    at Object.<anonymous> (/usr/local/lib/node_modules/mcdev/lib/cli.js:295:12)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
