### PR TITLE
Bugfix/187 mcdev bdb fails to find template where name and key differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 <a id="markdown-accenture-sfmc-devtools" name="accenture-sfmc-devtools"></a>
 
-[![NPM](https://nodei.co/npm/mcdev.png?downloads=true&downloadRank=true&stars=true)](https://www.npmjs.com/package/mcdev)
+[![view on npm](https://badgen.net/github/release/Accenture/sfmc-devtools)](https://www.npmjs.org/package/mcdev)
+[![view on npm](https://badgen.net/npm/node/mcdev)](https://www.npmjs.org/package/mcdev)
+[![license](https://badgen.net/npm/license/mcdev)](https://www.npmjs.org/package/mcdev)
+[![npm module downloads](https://badgen.net/npm/dt/mcdev)](https://www.npmjs.org/package/mcdev)
+[![GitHub closed issues](https://badgen.net/github/closed-issues/Accenture/sfmc-devtools)](https://github.com/Accenture/sfmc-devtools/issues?q=is%3Aissue+is%3Aclosed)
+[![GitHub releases](https://badgen.net/github/releases/Accenture/sfmc-devtools)](https://github.com/Accenture/sfmc-devtools/releases)
 
 Accenture Salesforce Marketing Cloud DevTools (mcdev) is a rapid deployment/rollout, backup and development tool for Salesforce Marketing Cloud. It allows you to retrieve and deploy configuration and code across Business Units and instances.
 

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -83,6 +83,12 @@ as this is a configuration in the EID</p>
 <dd><p>MetadataType class that gets extended by their specific metadata type class.
 Provides default functionality that can be overwritten by child metadata type classes</p>
 </dd>
+<dt><a href="#MobileCode">MobileCode</a> ⇐ <code><a href="#MetadataType">MetadataType</a></code></dt>
+<dd><p>MobileCode MetadataType</p>
+</dd>
+<dt><a href="#MobileKeyword">MobileKeyword</a> ⇐ <code><a href="#MetadataType">MetadataType</a></code></dt>
+<dd><p>MobileKeyword MetadataType</p>
+</dd>
 <dt><a href="#Query">Query</a> ⇐ <code><a href="#MetadataType">MetadataType</a></code></dt>
 <dd><p>Query MetadataType</p>
 </dd>
@@ -174,13 +180,13 @@ Provides default functionality that can be overwritten by child metadata type cl
 <dd></dd>
 <dt><a href="#DataExtensionFieldMap">DataExtensionFieldMap</a> : <code>Object</code></dt>
 <dd></dd>
-<dt><a href="#MultiMetadataTypeMap">MultiMetadataTypeMap</a> : <code>Object.&lt;string, any&gt;</code></dt>
+<dt><a href="#CodeExtract">CodeExtract</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="#CodeExtractItem">CodeExtractItem</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="#CodeExtractItem">CodeExtractItem</a> : <code>Object</code></dt>
 <dd></dd>
-<dt><a href="#TemplateMap">TemplateMap</a> : <code>Object.&lt;string, string&gt;</code></dt>
+<dt><a href="#MultiMetadataTypeList">MultiMetadataTypeList</a> : <code>Object.&lt;string, string&gt;</code></dt>
 <dd></dd>
 </dl>
 
@@ -345,7 +351,7 @@ main class
 
 * [Mcdev](#Mcdev)
     * [.createDeltaPkg(argv)](#Mcdev.createDeltaPkg) ⇒ <code>void</code>
-    * [._setLoggingLevel(argv)](#Mcdev._setLoggingLevel) ⇒ <code>void</code>
+    * [.setLoggingLevel(argv)](#Mcdev.setLoggingLevel) ⇒ <code>void</code>
     * [.selectTypes()](#Mcdev.selectTypes) ⇒ <code>Promise</code>
     * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>Promise</code>
     * [.upgrade([skipInteraction])](#Mcdev.upgrade) ⇒ <code>Promise</code>
@@ -358,7 +364,7 @@ main class
     * [.document(businessUnit, type)](#Mcdev.document) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.deleteByKey(businessUnit, type, customerKey)](#Mcdev.deleteByKey) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.badKeys(businessUnit)](#Mcdev.badKeys) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.retrieveAsTemplate(businessUnit, selectedType, name, market)](#Mcdev.retrieveAsTemplate) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.retrieveAsTemplate(businessUnit, selectedType, name, market)](#Mcdev.retrieveAsTemplate) ⇒ <code>Promise.&lt;Util.MultiMetadataTypeList&gt;</code>
     * [.buildDefinition(businessUnit, type, name, market)](#Mcdev.buildDefinition) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._checkMarket(market)](#Mcdev._checkMarket) ⇒ <code>Boolean</code>
     * [.buildDefinitionBulk(listName, type, name)](#Mcdev.buildDefinitionBulk) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -377,9 +383,9 @@ handler for 'mcdev createDeltaPkg
 | [argv.filter] | <code>String</code> | filter file paths that start with any |
 | [argv.skipInteraction] | <code>Boolean</code> | allows to skip interactive wizard |
 
-<a name="Mcdev._setLoggingLevel"></a>
+<a name="Mcdev.setLoggingLevel"></a>
 
-### Mcdev.\_setLoggingLevel(argv) ⇒ <code>void</code>
+### Mcdev.setLoggingLevel(argv) ⇒ <code>void</code>
 configures what is displayed in the console
 
 **Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
@@ -533,11 +539,11 @@ Converts metadata to legacy format. Output is saved in 'converted' directory
 
 <a name="Mcdev.retrieveAsTemplate"></a>
 
-### Mcdev.retrieveAsTemplate(businessUnit, selectedType, name, market) ⇒ <code>Promise.&lt;void&gt;</code>
+### Mcdev.retrieveAsTemplate(businessUnit, selectedType, name, market) ⇒ <code>Promise.&lt;Util.MultiMetadataTypeList&gt;</code>
 Retrieve a specific metadata file and templatise.
 
 **Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - -  
+**Returns**: <code>Promise.&lt;Util.MultiMetadataTypeList&gt;</code> - -  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -596,6 +602,7 @@ MessageSendActivity MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [AccountUser](#AccountUser) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#AccountUser.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir, _, buObject)](#AccountUser.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.timeSinceDate(date, date2)](#AccountUser.timeSinceDate) ⇒ <code>number</code>
     * [.getBuName(buObject, id)](#AccountUser.getBuName) ⇒ <code>string</code>
@@ -604,6 +611,10 @@ MessageSendActivity MetadataType
     * [.postRetrieveTasks(metadata)](#AccountUser.postRetrieveTasks) ⇒ <code>Array.&lt;Object&gt;</code>
     * [.parseMetadata(metadata)](#AccountUser.parseMetadata) ⇒ <code>Array</code>
 
+<a name="AccountUser.client"></a>
+
+### AccountUser.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>AccountUser</code>](#AccountUser)  
 <a name="AccountUser.retrieve"></a>
 
 ### AccountUser.retrieve(retrieveDir, _, buObject) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -702,6 +713,7 @@ FileTransfer MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [Asset](#Asset) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Asset.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir, _, __, [selectedSubType])](#Asset.retrieve) ⇒ <code>Promise.&lt;{metadata:AssetMap, type:string}&gt;</code>
     * [.retrieveForCache(_, [selectedSubType])](#Asset.retrieveForCache) ⇒ <code>Promise.&lt;{metadata:AssetMap, type:string}&gt;</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables, [selectedSubType])](#Asset.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata:AssetMap, type:string}&gt;</code>
@@ -724,6 +736,10 @@ FileTransfer MetadataType
     * [.findSubType(templateDir, templateName)](#Asset.findSubType) ⇒ <code>AssetSubType</code>
     * [.readSecondaryFolder(templateDir, typeDirArr, templateName, fileName)](#Asset.readSecondaryFolder) ⇒ <code>AssetItem</code>
 
+<a name="Asset.client"></a>
+
+### Asset.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Asset</code>](#Asset)  
 <a name="Asset.retrieve"></a>
 
 ### Asset.retrieve(retrieveDir, _, __, [selectedSubType]) ⇒ <code>Promise.&lt;{metadata:AssetMap, type:string}&gt;</code>
@@ -1026,9 +1042,14 @@ AttributeGroup MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [AttributeGroup](#AttributeGroup) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#AttributeGroup.client) : <code>Util.SDK</code>
     * [.retrieveForCache()](#AttributeGroup.retrieveForCache) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.retrieve(retrieveDir)](#AttributeGroup.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
 
+<a name="AttributeGroup.client"></a>
+
+### AttributeGroup.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>AttributeGroup</code>](#AttributeGroup)  
 <a name="AttributeGroup.retrieveForCache"></a>
 
 ### AttributeGroup.retrieveForCache() ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -1256,9 +1277,14 @@ Campaign MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [Campaign](#Campaign) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Campaign.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#Campaign.retrieve) ⇒ <code>Promise</code>
     * [.getAssetTags(retrieveDir, id, name)](#Campaign.getAssetTags) ⇒ <code>Promise.&lt;Object&gt;</code>
 
+<a name="Campaign.client"></a>
+
+### Campaign.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Campaign</code>](#Campaign)  
 <a name="Campaign.retrieve"></a>
 
 ### Campaign.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -1354,6 +1380,7 @@ DataExtension MetadataType
     * [.postRetrieveTasks(metadata, [_], [isTemplating])](#DataExtension.postRetrieveTasks) ⇒ <code>DataExtensionItem</code>
     * [.preDeployTasks(metadata)](#DataExtension.preDeployTasks) ⇒ <code>Promise.&lt;DataExtensionItem&gt;</code>
     * [.document(buObject, [metadata], [isDeploy])](#DataExtension.document) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.deleteByKey(buObject, customerKey)](#DataExtension.deleteByKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.postDeleteTasks(buObject, customerKey)](#DataExtension.postDeleteTasks) ⇒ <code>void</code>
     * [.retrieveForCache(buObject, [_], [isDeploy])](#DataExtension.retrieveForCache) ⇒ <code>Promise</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#DataExtension.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata:DataExtensionMap, type:string}&gt;</code>
@@ -1492,6 +1519,19 @@ Parses metadata into a readable Markdown/HTML format then saves it
 | [metadata] | [<code>DataExtensionMap</code>](#DataExtensionMap) | a list of dataExtension definitions |
 | [isDeploy] | <code>boolean</code> | used to skip non-supported message during deploy |
 
+<a name="DataExtension.deleteByKey"></a>
+
+### DataExtension.deleteByKey(buObject, customerKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
+Delete a metadata item from the specified business unit
+
+**Kind**: static method of [<code>DataExtension</code>](#DataExtension)  
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - deletion success status  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| buObject | <code>Util.BuObject</code> | references credentials |
+| customerKey | <code>string</code> | Identifier of data extension |
+
 <a name="DataExtension.postDeleteTasks"></a>
 
 ### DataExtension.postDeleteTasks(buObject, customerKey) ⇒ <code>void</code>
@@ -1542,15 +1582,21 @@ DataExtensionField MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [DataExtensionField](#DataExtensionField) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#DataExtensionField.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir, [additionalFields], buObject)](#DataExtensionField.retrieve) ⇒ <code>Promise.&lt;{metadata:DataExtensionFieldMap, type:string}&gt;</code>
     * [.retrieveForCache([requestParams], [additionalFields])](#DataExtensionField.retrieveForCache) ⇒ <code>Promise.&lt;{metadata:DataExtensionFieldMap, type:string}&gt;</code>
     * [.convertToSortedArray(fieldsObj)](#DataExtensionField.convertToSortedArray) ⇒ <code>Array.&lt;DataExtensionFieldItem&gt;</code>
     * [.sortDeFields(a, b)](#DataExtensionField.sortDeFields) ⇒ <code>boolean</code>
     * [.postRetrieveTasks(metadata, forDataExtension)](#DataExtensionField.postRetrieveTasks) ⇒ <code>DataExtensionFieldItem</code>
     * [.prepareDeployColumnsOnUpdate(deployColumns, deKey)](#DataExtensionField.prepareDeployColumnsOnUpdate) ⇒ <code>Object.&lt;string, DataExtensionFieldItem&gt;</code>
+    * [.deleteByKey(buObject, customerKey)](#DataExtensionField.deleteByKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.deleteByKeySOAP(buObject, customerKey, [handleOutside])](#DataExtensionField.deleteByKeySOAP) ⇒ <code>boolean</code>
     * [.postDeleteTasks(customerKey)](#DataExtensionField.postDeleteTasks) ⇒ <code>void</code>
 
+<a name="DataExtensionField.client"></a>
+
+### DataExtensionField.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>DataExtensionField</code>](#DataExtensionField)  
 <a name="DataExtensionField.retrieve"></a>
 
 ### DataExtensionField.retrieve(retrieveDir, [additionalFields], buObject) ⇒ <code>Promise.&lt;{metadata:DataExtensionFieldMap, type:string}&gt;</code>
@@ -1630,6 +1676,19 @@ Removes FieldType field if its the same in deploy and target column, because it 
 | deployColumns | <code>Array.&lt;DataExtensionFieldItem&gt;</code> | Columns of data extension that will be deployed |
 | deKey | <code>string</code> | external/customer key of Data Extension |
 
+<a name="DataExtensionField.deleteByKey"></a>
+
+### DataExtensionField.deleteByKey(buObject, customerKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
+Delete a metadata item from the specified business unit
+
+**Kind**: static method of [<code>DataExtensionField</code>](#DataExtensionField)  
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - deletion success status  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| buObject | <code>Util.BuObject</code> | references credentials |
+| customerKey | <code>string</code> | Identifier of data extension |
+
 <a name="DataExtensionField.deleteByKeySOAP"></a>
 
 ### DataExtensionField.deleteByKeySOAP(buObject, customerKey, [handleOutside]) ⇒ <code>boolean</code>
@@ -1684,6 +1743,7 @@ DataExtract MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [DataExtract](#DataExtract) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#DataExtract.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#DataExtract.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.retrieveForCache()](#DataExtract.retrieveForCache) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#DataExtract.retrieveAsTemplate) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -1693,6 +1753,10 @@ DataExtract MetadataType
     * [.preDeployTasks(metadata)](#DataExtract.preDeployTasks) ⇒ <code>Object</code>
     * [.parseMetadata(metadata)](#DataExtract.parseMetadata) ⇒ <code>Array</code>
 
+<a name="DataExtract.client"></a>
+
+### DataExtract.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>DataExtract</code>](#DataExtract)  
 <a name="DataExtract.retrieve"></a>
 
 ### DataExtract.retrieve(retrieveDir) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -1900,13 +1964,19 @@ MessageSendActivity MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [EmailSendDefinition](#EmailSendDefinition) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#EmailSendDefinition.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir, _, buObject)](#EmailSendDefinition.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.update(metadataItem)](#EmailSendDefinition.update) ⇒ <code>Promise</code>
     * [.create(metadataItem)](#EmailSendDefinition.create) ⇒ <code>Promise</code>
+    * [.deleteByKey(buObject, customerKey)](#EmailSendDefinition.deleteByKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.preDeployTasks(metadata)](#EmailSendDefinition.preDeployTasks) ⇒ <code>Promise</code>
     * [.postRetrieveTasks(metadata)](#EmailSendDefinition.postRetrieveTasks) ⇒ <code>Array.&lt;Object&gt;</code>
     * [.parseMetadata(metadata)](#EmailSendDefinition.parseMetadata) ⇒ <code>Array</code>
 
+<a name="EmailSendDefinition.client"></a>
+
+### EmailSendDefinition.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>EmailSendDefinition</code>](#EmailSendDefinition)  
 <a name="EmailSendDefinition.retrieve"></a>
 
 ### EmailSendDefinition.retrieve(retrieveDir, _, buObject) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -1944,6 +2014,19 @@ Creates a single item
 | Param | Type | Description |
 | --- | --- | --- |
 | metadataItem | <code>Object</code> | a single item |
+
+<a name="EmailSendDefinition.deleteByKey"></a>
+
+### EmailSendDefinition.deleteByKey(buObject, customerKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
+Delete a metadata item from the specified business unit
+
+**Kind**: static method of [<code>EmailSendDefinition</code>](#EmailSendDefinition)  
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - deletion success status  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| buObject | <code>Util.BuObject</code> | references credentials |
+| customerKey | <code>string</code> | Identifier of data extension |
 
 <a name="EmailSendDefinition.preDeployTasks"></a>
 
@@ -1990,6 +2073,7 @@ EventDefinition MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [EventDefinition](#EventDefinition) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#EventDefinition.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#EventDefinition.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.retrieveForCache()](#EventDefinition.retrieveForCache) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#EventDefinition.retrieveAsTemplate) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -1999,6 +2083,10 @@ EventDefinition MetadataType
     * [.preDeployTasks(metadata)](#EventDefinition.preDeployTasks) ⇒ <code>Promise</code>
     * [.parseMetadata(metadata)](#EventDefinition.parseMetadata) ⇒ <code>Array</code>
 
+<a name="EventDefinition.client"></a>
+
+### EventDefinition.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>EventDefinition</code>](#EventDefinition)  
 <a name="EventDefinition.retrieve"></a>
 
 ### EventDefinition.retrieve(retrieveDir) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -2103,6 +2191,7 @@ FileTransfer MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [FileTransfer](#FileTransfer) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#FileTransfer.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#FileTransfer.retrieve) ⇒ <code>Promise</code>
     * [.retrieveForCache()](#FileTransfer.retrieveForCache) ⇒ <code>Promise</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#FileTransfer.retrieveAsTemplate) ⇒ <code>Promise</code>
@@ -2112,6 +2201,10 @@ FileTransfer MetadataType
     * [.preDeployTasks(metadata)](#FileTransfer.preDeployTasks) ⇒ <code>Promise</code>
     * [.parseMetadata(metadata)](#FileTransfer.parseMetadata) ⇒ <code>Array</code>
 
+<a name="FileTransfer.client"></a>
+
+### FileTransfer.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>FileTransfer</code>](#FileTransfer)  
 <a name="FileTransfer.retrieve"></a>
 
 ### FileTransfer.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -2237,6 +2330,7 @@ Folder MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [Folder](#Folder) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Folder.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir, [additionalFields], buObject)](#Folder.retrieve) ⇒ <code>Promise</code>
     * [.retrieveForCache(buObject)](#Folder.retrieveForCache) ⇒ <code>Promise</code>
     * [.upsert(metadata)](#Folder.upsert) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -2248,6 +2342,10 @@ Folder MetadataType
     * [.postRetrieveTasks(metadata)](#Folder.postRetrieveTasks) ⇒ <code>Array.&lt;Object&gt;</code>
     * [.saveResults(results, retrieveDir, mid)](#Folder.saveResults) ⇒ <code>Promise.&lt;Object&gt;</code>
 
+<a name="Folder.client"></a>
+
+### Folder.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Folder</code>](#Folder)  
 <a name="Folder.retrieve"></a>
 
 ### Folder.retrieve(retrieveDir, [additionalFields], buObject) ⇒ <code>Promise</code>
@@ -2385,9 +2483,14 @@ ImportFile MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [FtpLocation](#FtpLocation) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#FtpLocation.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#FtpLocation.retrieve) ⇒ <code>Promise</code>
     * [.retrieveForCache()](#FtpLocation.retrieveForCache) ⇒ <code>Promise</code>
 
+<a name="FtpLocation.client"></a>
+
+### FtpLocation.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>FtpLocation</code>](#FtpLocation)  
 <a name="FtpLocation.retrieve"></a>
 
 ### FtpLocation.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -2417,6 +2520,7 @@ ImportFile MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [ImportFile](#ImportFile) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#ImportFile.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#ImportFile.retrieve) ⇒ <code>Promise</code>
     * [.retrieveForCache()](#ImportFile.retrieveForCache) ⇒ <code>Promise</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#ImportFile.retrieveAsTemplate) ⇒ <code>Promise</code>
@@ -2426,6 +2530,10 @@ ImportFile MetadataType
     * [.preDeployTasks(metadata)](#ImportFile.preDeployTasks) ⇒ <code>Promise</code>
     * [.parseMetadata(metadata)](#ImportFile.parseMetadata) ⇒ <code>Object</code>
 
+<a name="ImportFile.client"></a>
+
+### ImportFile.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>ImportFile</code>](#ImportFile)  
 <a name="ImportFile.retrieve"></a>
 
 ### ImportFile.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -2528,6 +2636,15 @@ Script MetadataType
 
 **Kind**: global class  
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
+
+* [Interaction](#Interaction) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Interaction.client) : <code>Util.SDK</code>
+    * [.retrieve(retrieveDir)](#Interaction.retrieve) ⇒ <code>Promise</code>
+
+<a name="Interaction.client"></a>
+
+### Interaction.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Interaction</code>](#Interaction)  
 <a name="Interaction.retrieve"></a>
 
 ### Interaction.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -2550,11 +2667,17 @@ List MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [List](#List) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#List.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#List.retrieve) ⇒ <code>Promise</code>
     * [.retrieveForCache()](#List.retrieveForCache) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.deleteByKey(buObject, customerKey)](#List.deleteByKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.postRetrieveTasks(list)](#List.postRetrieveTasks) ⇒ <code>Array.&lt;Object&gt;</code>
     * [.parseMetadata(metadata, [parseForCache])](#List.parseMetadata) ⇒ <code>Array</code>
 
+<a name="List.client"></a>
+
+### List.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>List</code>](#List)  
 <a name="List.retrieve"></a>
 
 ### List.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -2574,6 +2697,19 @@ Gets metadata cache with limited fields and does not store value to disk
 
 **Kind**: static method of [<code>List</code>](#List)  
 **Returns**: <code>Promise.&lt;Object&gt;</code> - Promise of metadata  
+<a name="List.deleteByKey"></a>
+
+### List.deleteByKey(buObject, customerKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
+Delete a metadata item from the specified business unit
+
+**Kind**: static method of [<code>List</code>](#List)  
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - deletion success status  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| buObject | <code>Util.BuObject</code> | references credentials |
+| customerKey | <code>string</code> | Identifier of data extension |
+
 <a name="List.postRetrieveTasks"></a>
 
 ### List.postRetrieveTasks(list) ⇒ <code>Array.&lt;Object&gt;</code>
@@ -2610,29 +2746,29 @@ Provides default functionality that can be overwritten by child metadata type cl
 * [MetadataType](#MetadataType)
     * [new MetadataType(client, businessUnit, cache, properties, [subType])](#new_MetadataType_new)
     * [.client](#MetadataType.client) : <code>Util.SDK</code>
-    * [.cache](#MetadataType.cache) : [<code>MultiMetadataTypeMap</code>](#MultiMetadataTypeMap)
+    * [.cache](#MetadataType.cache) : <code>Util.MultiMetadataTypeMap</code>
     * [.getJsonFromFS(dir, [listBadKeys])](#MetadataType.getJsonFromFS) ⇒ <code>Object</code>
     * [.getFieldNamesToRetrieve([additionalFields])](#MetadataType.getFieldNamesToRetrieve) ⇒ <code>Array.&lt;string&gt;</code>
     * [.deploy(metadata, deployDir, retrieveDir, buObject)](#MetadataType.deploy) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.postDeployTasks(metadata, originalMetadata)](#MetadataType.postDeployTasks) ⇒ <code>void</code>
-    * [.postRetrieveTasks(metadata, targetDir, [isTemplating])](#MetadataType.postRetrieveTasks) ⇒ <code>MetadataTypeItem</code>
+    * [.postRetrieveTasks(metadata, targetDir, [isTemplating])](#MetadataType.postRetrieveTasks) ⇒ <code>Util.MetadataTypeItem</code>
     * [.overrideKeyWithName(metadata, [warningMsg])](#MetadataType.overrideKeyWithName) ⇒ <code>void</code>
-    * [.retrieve(retrieveDir, [additionalFields], buObject, [subType])](#MetadataType.retrieve) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.retrieveChangelog([additionalFields], buObject, [subType])](#MetadataType.retrieveChangelog) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.retrieveForCache(buObject, [subType])](#MetadataType.retrieveForCache) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.retrieveAsTemplate(templateDir, name, templateVariables, [subType])](#MetadataType.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.preDeployTasks(metadata, deployDir)](#MetadataType.preDeployTasks) ⇒ <code>Promise.&lt;MetadataTypeItem&gt;</code>
+    * [.retrieve(retrieveDir, [additionalFields], buObject, [subType])](#MetadataType.retrieve) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.retrieveChangelog([additionalFields], buObject, [subType])](#MetadataType.retrieveChangelog) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.retrieveForCache(buObject, [subType])](#MetadataType.retrieveForCache) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.retrieveAsTemplate(templateDir, name, templateVariables, [subType])](#MetadataType.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.preDeployTasks(metadata, deployDir)](#MetadataType.preDeployTasks) ⇒ <code>Promise.&lt;Util.MetadataTypeItem&gt;</code>
     * [.create(metadata, deployDir)](#MetadataType.create) ⇒ <code>void</code>
     * [.update(metadata, [metadataBefore])](#MetadataType.update) ⇒ <code>void</code>
-    * [.upsert(metadata, deployDir, [buObject])](#MetadataType.upsert) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+    * [.upsert(metadata, deployDir, [buObject])](#MetadataType.upsert) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
     * [.createREST(metadataEntry, uri)](#MetadataType.createREST) ⇒ <code>Promise</code>
     * [.createSOAP(metadataEntry, [overrideType], [handleOutside])](#MetadataType.createSOAP) ⇒ <code>Promise</code>
     * [.updateREST(metadataEntry, uri)](#MetadataType.updateREST) ⇒ <code>Promise</code>
     * [.updateSOAP(metadataEntry, [overrideType], [handleOutside])](#MetadataType.updateSOAP) ⇒ <code>Promise</code>
-    * [.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType])](#MetadataType.retrieveSOAPgeneric) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.retrieveSOAPBody(fields, [options], [type])](#MetadataType.retrieveSOAPBody) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
-    * [.retrieveREST(retrieveDir, uri, [overrideType], [templateVariables])](#MetadataType.retrieveREST) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.parseResponseBody(body)](#MetadataType.parseResponseBody) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+    * [.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType])](#MetadataType.retrieveSOAPgeneric) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.retrieveSOAPBody(fields, [options], [type])](#MetadataType.retrieveSOAPBody) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
+    * [.retrieveREST(retrieveDir, uri, [overrideType], [templateVariables])](#MetadataType.retrieveREST) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.parseResponseBody(body)](#MetadataType.parseResponseBody) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
     * [.deleteFieldByDefinition(metadataEntry, fieldPath, definitionProperty, origin)](#MetadataType.deleteFieldByDefinition) ⇒ <code>void</code>
     * [.removeNotCreateableFields(metadataEntry)](#MetadataType.removeNotCreateableFields) ⇒ <code>void</code>
     * [.removeNotUpdateableFields(metadataEntry)](#MetadataType.removeNotUpdateableFields) ⇒ <code>void</code>
@@ -2640,14 +2776,14 @@ Provides default functionality that can be overwritten by child metadata type cl
     * [.keepRetrieveFields(metadataEntry)](#MetadataType.keepRetrieveFields) ⇒ <code>void</code>
     * [.isFiltered(metadataEntry, [include])](#MetadataType.isFiltered) ⇒ <code>boolean</code>
     * [.isFilteredFolder(metadataEntry, [include])](#MetadataType.isFilteredFolder) ⇒ <code>boolean</code>
-    * [.saveResults(results, retrieveDir, [overrideType], [templateVariables])](#MetadataType.saveResults) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+    * [.saveResults(results, retrieveDir, [overrideType], [templateVariables])](#MetadataType.saveResults) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
     * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName)](#MetadataType.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.findSubType(templateDir, templateName)](#MetadataType.findSubType) ⇒ <code>string</code>
     * [.readSecondaryFolder(templateDir, typeDirArr, templateName, fileName, ex)](#MetadataType.readSecondaryFolder) ⇒ <code>Object</code>
-    * [.buildDefinition(templateDir, targetDir, templateName, variables)](#MetadataType.buildDefinition) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
-    * [.checkForErrors(ex)](#MetadataType.checkForErrors) ⇒ <code>void</code>
+    * [.buildDefinition(templateDir, targetDir, templateName, variables)](#MetadataType.buildDefinition) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+    * [.checkForErrors(ex)](#MetadataType.checkForErrors) ⇒ <code>string</code>
     * [.document([buObject], [metadata], [isDeploy])](#MetadataType.document) ⇒ <code>void</code>
-    * [.deleteByKey(buObject, customerKey)](#MetadataType.deleteByKey) ⇒ <code>void</code>
+    * [.deleteByKey(buObject, customerKey)](#MetadataType.deleteByKey) ⇒ <code>boolean</code>
     * [.postDeleteTasks(buObject, customerKey)](#MetadataType.postDeleteTasks) ⇒ <code>void</code>
     * [.deleteByKeySOAP(buObject, customerKey, [handleOutside])](#MetadataType.deleteByKeySOAP) ⇒ <code>boolean</code>
     * [.readBUMetadataForType(readDir, [listBadKeys], [buMetadata])](#MetadataType.readBUMetadataForType) ⇒ <code>Object</code>
@@ -2672,7 +2808,7 @@ Instantiates a metadata constructor to avoid passing variables.
 **Kind**: static property of [<code>MetadataType</code>](#MetadataType)  
 <a name="MetadataType.cache"></a>
 
-### MetadataType.cache : [<code>MultiMetadataTypeMap</code>](#MultiMetadataTypeMap)
+### MetadataType.cache : <code>Util.MultiMetadataTypeMap</code>
 **Kind**: static property of [<code>MetadataType</code>](#MetadataType)  
 <a name="MetadataType.getJsonFromFS"></a>
 
@@ -2709,7 +2845,7 @@ Deploys metadata
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeMap</code> | metadata mapped by their keyField |
+| metadata | <code>Util.MetadataTypeMap</code> | metadata mapped by their keyField |
 | deployDir | <code>string</code> | directory where deploy metadata are saved |
 | retrieveDir | <code>string</code> | directory where metadata after deploy should be saved |
 | buObject | <code>Util.BuObject</code> | properties for auth |
@@ -2723,20 +2859,20 @@ Gets executed after deployment of metadata type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeMap</code> | metadata mapped by their keyField |
-| originalMetadata | <code>MetadataTypeMap</code> | metadata to be updated (contains additioanl fields) |
+| metadata | <code>Util.MetadataTypeMap</code> | metadata mapped by their keyField |
+| originalMetadata | <code>Util.MetadataTypeMap</code> | metadata to be updated (contains additioanl fields) |
 
 <a name="MetadataType.postRetrieveTasks"></a>
 
-### MetadataType.postRetrieveTasks(metadata, targetDir, [isTemplating]) ⇒ <code>MetadataTypeItem</code>
+### MetadataType.postRetrieveTasks(metadata, targetDir, [isTemplating]) ⇒ <code>Util.MetadataTypeItem</code>
 Gets executed after retreive of metadata type
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>MetadataTypeItem</code> - cloned metadata  
+**Returns**: <code>Util.MetadataTypeItem</code> - cloned metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeItem</code> | a single item |
+| metadata | <code>Util.MetadataTypeItem</code> | a single item |
 | targetDir | <code>string</code> | folder where retrieves should be saved |
 | [isTemplating] | <code>boolean</code> | signals that we are retrieving templates |
 
@@ -2749,16 +2885,16 @@ used to synchronize name and external key during retrieveAsTemplate
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeItem</code> | a single item |
+| metadata | <code>Util.MetadataTypeItem</code> | a single item |
 | [warningMsg] | <code>string</code> | optional msg to show the user |
 
 <a name="MetadataType.retrieve"></a>
 
-### MetadataType.retrieve(retrieveDir, [additionalFields], buObject, [subType]) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieve(retrieveDir, [additionalFields], buObject, [subType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Gets metadata from Marketing Cloud
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - metadata  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2769,11 +2905,11 @@ Gets metadata from Marketing Cloud
 
 <a name="MetadataType.retrieveChangelog"></a>
 
-### MetadataType.retrieveChangelog([additionalFields], buObject, [subType]) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveChangelog([additionalFields], buObject, [subType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Gets metadata from Marketing Cloud
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - metadata  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2783,11 +2919,11 @@ Gets metadata from Marketing Cloud
 
 <a name="MetadataType.retrieveForCache"></a>
 
-### MetadataType.retrieveForCache(buObject, [subType]) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveForCache(buObject, [subType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Gets metadata cache with limited fields and does not store value to disk
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - metadata  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2796,11 +2932,11 @@ Gets metadata cache with limited fields and does not store value to disk
 
 <a name="MetadataType.retrieveAsTemplate"></a>
 
-### MetadataType.retrieveAsTemplate(templateDir, name, templateVariables, [subType]) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveAsTemplate(templateDir, name, templateVariables, [subType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Gets metadata cache with limited fields and does not store value to disk
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - metadata  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2811,15 +2947,15 @@ Gets metadata cache with limited fields and does not store value to disk
 
 <a name="MetadataType.preDeployTasks"></a>
 
-### MetadataType.preDeployTasks(metadata, deployDir) ⇒ <code>Promise.&lt;MetadataTypeItem&gt;</code>
+### MetadataType.preDeployTasks(metadata, deployDir) ⇒ <code>Promise.&lt;Util.MetadataTypeItem&gt;</code>
 Gets executed before deploying metadata
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;MetadataTypeItem&gt;</code> - Promise of a single metadata item  
+**Returns**: <code>Promise.&lt;Util.MetadataTypeItem&gt;</code> - Promise of a single metadata item  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeItem</code> | a single metadata item |
+| metadata | <code>Util.MetadataTypeItem</code> | a single metadata item |
 | deployDir | <code>string</code> | folder where files for deployment are stored |
 
 <a name="MetadataType.create"></a>
@@ -2831,7 +2967,7 @@ Abstract create method that needs to be implemented in child metadata type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeItem</code> | single metadata entry |
+| metadata | <code>Util.MetadataTypeItem</code> | single metadata entry |
 | deployDir | <code>string</code> | directory where deploy metadata are saved |
 
 <a name="MetadataType.update"></a>
@@ -2843,20 +2979,20 @@ Abstract update method that needs to be implemented in child metadata type
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeItem</code> | single metadata entry |
-| [metadataBefore] | <code>MetadataTypeItem</code> | metadata mapped by their keyField |
+| metadata | <code>Util.MetadataTypeItem</code> | single metadata entry |
+| [metadataBefore] | <code>Util.MetadataTypeItem</code> | metadata mapped by their keyField |
 
 <a name="MetadataType.upsert"></a>
 
-### MetadataType.upsert(metadata, deployDir, [buObject]) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+### MetadataType.upsert(metadata, deployDir, [buObject]) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
 MetadataType upsert, after retrieving from target and comparing to check if create or update operation is needed.
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;MetadataTypeMap&gt;</code> - keyField => metadata map  
+**Returns**: <code>Promise.&lt;Util.MetadataTypeMap&gt;</code> - keyField => metadata map  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadata | <code>MetadataTypeMap</code> | metadata mapped by their keyField |
+| metadata | <code>Util.MetadataTypeMap</code> | metadata mapped by their keyField |
 | deployDir | <code>string</code> | directory where deploy metadata are saved |
 | [buObject] | <code>Util.BuObject</code> | properties for auth |
 
@@ -2870,7 +3006,7 @@ Creates a single metadata entry via REST
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | a single metadata Entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | a single metadata Entry |
 | uri | <code>string</code> | rest endpoint for POST |
 
 <a name="MetadataType.createSOAP"></a>
@@ -2883,7 +3019,7 @@ Creates a single metadata entry via fuel-soap (generic lib not wrapper)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | single metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | single metadata entry |
 | [overrideType] | <code>string</code> | can be used if the API type differs from the otherwise used type identifier |
 | [handleOutside] | <code>boolean</code> | if the API reponse is irregular this allows you to handle it outside of this generic method |
 
@@ -2897,7 +3033,7 @@ Updates a single metadata entry via REST
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | a single metadata Entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | a single metadata Entry |
 | uri | <code>string</code> | rest endpoint for PATCH |
 
 <a name="MetadataType.updateSOAP"></a>
@@ -2910,17 +3046,17 @@ Updates a single metadata entry via fuel-soap (generic lib not wrapper)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | single metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | single metadata entry |
 | [overrideType] | <code>string</code> | can be used if the API type differs from the otherwise used type identifier |
 | [handleOutside] | <code>boolean</code> | if the API reponse is irregular this allows you to handle it outside of this generic method |
 
 <a name="MetadataType.retrieveSOAPgeneric"></a>
 
-### MetadataType.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType]) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Retrieves SOAP via generic fuel-soap wrapper based metadata of metadata type into local filesystem. executes callback with retrieved metadata
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - Promise of item map  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - Promise of item map  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2932,11 +3068,11 @@ Retrieves SOAP via generic fuel-soap wrapper based metadata of metadata type int
 
 <a name="MetadataType.retrieveSOAPBody"></a>
 
-### MetadataType.retrieveSOAPBody(fields, [options], [type]) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+### MetadataType.retrieveSOAPBody(fields, [options], [type]) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
 helper that handles batched retrieve via SOAP
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;MetadataTypeMap&gt;</code> - keyField => metadata map  
+**Returns**: <code>Promise.&lt;Util.MetadataTypeMap&gt;</code> - keyField => metadata map  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2946,11 +3082,11 @@ helper that handles batched retrieve via SOAP
 
 <a name="MetadataType.retrieveREST"></a>
 
-### MetadataType.retrieveREST(retrieveDir, uri, [overrideType], [templateVariables]) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveREST(retrieveDir, uri, [overrideType], [templateVariables]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Retrieves Metadata for Rest Types
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - Promise of item map  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - Promise of item map  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2961,11 +3097,11 @@ Retrieves Metadata for Rest Types
 
 <a name="MetadataType.parseResponseBody"></a>
 
-### MetadataType.parseResponseBody(body) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+### MetadataType.parseResponseBody(body) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
 Builds map of metadata entries mapped to their keyfields
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;MetadataTypeMap&gt;</code> - keyField => metadata map  
+**Returns**: <code>Promise.&lt;Util.MetadataTypeMap&gt;</code> - keyField => metadata map  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -2980,7 +3116,7 @@ Deletes a field in a metadata entry if the selected definition property equals f
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | One entry of a metadataType |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | One entry of a metadataType |
 | fieldPath | <code>string</code> | field path to be checked if it conforms to the definition (dot seperated if nested): 'fuu.bar' |
 | definitionProperty | <code>&#x27;isCreateable&#x27;</code> \| <code>&#x27;isUpdateable&#x27;</code> \| <code>&#x27;retrieving&#x27;</code> \| <code>&#x27;templating&#x27;</code> | delete field if definitionProperty equals false for specified field. Options: [isCreateable | isUpdateable] |
 | origin | <code>string</code> | string of parent object, required when using arrays as these are parsed slightly differently. |
@@ -2999,7 +3135,7 @@ Remove fields from metadata entry that are not createable
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | metadata entry |
 
 <a name="MetadataType.removeNotUpdateableFields"></a>
 
@@ -3010,7 +3146,7 @@ Remove fields from metadata entry that are not updateable
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | metadata entry |
 
 <a name="MetadataType.keepTemplateFields"></a>
 
@@ -3021,7 +3157,7 @@ Remove fields from metadata entry that are not needed in the template
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | metadata entry |
 
 <a name="MetadataType.keepRetrieveFields"></a>
 
@@ -3032,7 +3168,7 @@ Remove fields from metadata entry that are not needed in the stored metadata
 
 | Param | Type | Description |
 | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> | metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> | metadata entry |
 
 <a name="MetadataType.isFiltered"></a>
 
@@ -3044,7 +3180,7 @@ checks if the current metadata entry should be saved on retrieve or not
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| metadataEntry | <code>MetadataTypeItem</code> |  | metadata entry |
+| metadataEntry | <code>Util.MetadataTypeItem</code> |  | metadata entry |
 | [include] | <code>boolean</code> | <code>false</code> | true: use definition.include / options.include; false=exclude: use definition.filter / options.exclude |
 
 <a name="MetadataType.isFilteredFolder"></a>
@@ -3062,15 +3198,15 @@ optionally filter by what folder something is in
 
 <a name="MetadataType.saveResults"></a>
 
-### MetadataType.saveResults(results, retrieveDir, [overrideType], [templateVariables]) ⇒ <code>Promise.&lt;MetadataTypeMap&gt;</code>
+### MetadataType.saveResults(results, retrieveDir, [overrideType], [templateVariables]) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
 Helper for writing Metadata to disk, used for Retrieve and deploy
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;MetadataTypeMap&gt;</code> - Promise of saved metadata  
+**Returns**: <code>Promise.&lt;Util.MetadataTypeMap&gt;</code> - Promise of saved metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| results | <code>MetadataTypeMap</code> | metadata results from deploy |
+| results | <code>Util.MetadataTypeMap</code> | metadata results from deploy |
 | retrieveDir | <code>string</code> | directory where metadata should be stored after deploy/retrieve |
 | [overrideType] | <code>string</code> | for use when there is a subtype (such as folder-queries) |
 | [templateVariables] | <code>Util.TemplateMap</code> | variables to be replaced in the metadata |
@@ -3088,7 +3224,7 @@ handles extracted code if any are found for complex types (e.g script, asset, qu
 | --- | --- | --- |
 | templateDir | <code>string</code> | Directory where metadata templates are stored |
 | targetDir | <code>string</code> | Directory where built definitions will be saved |
-| metadata | <code>MetadataTypeItem</code> | main JSON file that was read from file system |
+| metadata | <code>Util.MetadataTypeItem</code> | main JSON file that was read from file system |
 | variables | <code>Util.TemplateMap</code> | variables to be replaced in the metadata |
 | templateName | <code>string</code> | name of the template to be built |
 
@@ -3123,13 +3259,13 @@ optional method used for some types to try a different folder structure
 
 <a name="MetadataType.buildDefinition"></a>
 
-### MetadataType.buildDefinition(templateDir, targetDir, templateName, variables) ⇒ <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.buildDefinition(templateDir, targetDir, templateName, variables) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Builds definition based on template
 NOTE: Most metadata files should use this generic method, unless custom
 parsing is required (for example scripts & queries)
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;{metadata:MetadataTypeMap, type:string}&gt;</code> - Promise of item map  
+**Returns**: <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code> - Promise of item map  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3140,8 +3276,11 @@ parsing is required (for example scripts & queries)
 
 <a name="MetadataType.checkForErrors"></a>
 
-### MetadataType.checkForErrors(ex) ⇒ <code>void</code>
+### MetadataType.checkForErrors(ex) ⇒ <code>string</code>
+Standardizes a check for multiple messages
+
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
+**Returns**: <code>string</code> - formatted Error Message  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3157,16 +3296,16 @@ Gets metadata cache with limited fields and does not store value to disk
 | Param | Type | Description |
 | --- | --- | --- |
 | [buObject] | <code>Util.BuObject</code> | properties for auth |
-| [metadata] | <code>MetadataTypeMap</code> | a list of type definitions |
+| [metadata] | <code>Util.MetadataTypeMap</code> | a list of type definitions |
 | [isDeploy] | <code>boolean</code> | used to skip non-supported message during deploy |
 
 <a name="MetadataType.deleteByKey"></a>
 
-### MetadataType.deleteByKey(buObject, customerKey) ⇒ <code>void</code>
-Delete a data extension from the specified business unit
+### MetadataType.deleteByKey(buObject, customerKey) ⇒ <code>boolean</code>
+Delete a metadata item from the specified business unit
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>void</code> - -  
+**Returns**: <code>boolean</code> - deletion success status  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3214,6 +3353,111 @@ Returns metadata of a business unit that is saved locally
 | [listBadKeys] | <code>boolean</code> | <code>false</code> | do not print errors, used for badKeys() |
 | [buMetadata] | <code>Object</code> |  | Metadata of BU in local directory |
 
+<a name="MobileCode"></a>
+
+## MobileCode ⇐ [<code>MetadataType</code>](#MetadataType)
+MobileCode MetadataType
+
+**Kind**: global class  
+**Extends**: [<code>MetadataType</code>](#MetadataType)  
+
+* [MobileCode](#MobileCode) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.retrieve(retrieveDir)](#MobileCode.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.retrieveForCache()](#MobileCode.retrieveForCache) ⇒ <code>Promise.&lt;Object&gt;</code>
+
+<a name="MobileCode.retrieve"></a>
+
+### MobileCode.retrieve(retrieveDir) ⇒ <code>Promise.&lt;Object&gt;</code>
+Retrieves Metadata of Mobile Keywords
+Endpoint /legacy/v1/beta/mobile/code/ return all Mobile Codes with all details.
+
+**Kind**: static method of [<code>MobileCode</code>](#MobileCode)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - Promise of metadata  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| retrieveDir | <code>String</code> | Directory where retrieved metadata directory will be saved |
+
+<a name="MobileCode.retrieveForCache"></a>
+
+### MobileCode.retrieveForCache() ⇒ <code>Promise.&lt;Object&gt;</code>
+Retrieves event definition metadata for caching
+
+**Kind**: static method of [<code>MobileCode</code>](#MobileCode)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - Promise of metadata  
+<a name="MobileKeyword"></a>
+
+## MobileKeyword ⇐ [<code>MetadataType</code>](#MetadataType)
+MobileKeyword MetadataType
+
+**Kind**: global class  
+**Extends**: [<code>MetadataType</code>](#MetadataType)  
+
+* [MobileKeyword](#MobileKeyword) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.retrieve(retrieveDir)](#MobileKeyword.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.retrieveForCache()](#MobileKeyword.retrieveForCache) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.retrieveAsTemplate(templateDir, name, templateVariables)](#MobileKeyword.retrieveAsTemplate) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.create(MobileKeyword)](#MobileKeyword.create) ⇒ <code>Promise</code>
+    * [.preDeployTasks(metadata)](#MobileKeyword.preDeployTasks) ⇒ <code>Promise</code>
+
+<a name="MobileKeyword.retrieve"></a>
+
+### MobileKeyword.retrieve(retrieveDir) ⇒ <code>Promise.&lt;Object&gt;</code>
+Retrieves Metadata of Mobile Keywords
+Endpoint /legacy/v1/beta/mobile/keyword/ return all Mobile Keywords with all details.
+
+**Kind**: static method of [<code>MobileKeyword</code>](#MobileKeyword)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - Promise of metadata  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| retrieveDir | <code>String</code> | Directory where retrieved metadata directory will be saved |
+
+<a name="MobileKeyword.retrieveForCache"></a>
+
+### MobileKeyword.retrieveForCache() ⇒ <code>Promise.&lt;Object&gt;</code>
+Retrieves event definition metadata for caching
+
+**Kind**: static method of [<code>MobileKeyword</code>](#MobileKeyword)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - Promise of metadata  
+<a name="MobileKeyword.retrieveAsTemplate"></a>
+
+### MobileKeyword.retrieveAsTemplate(templateDir, name, templateVariables) ⇒ <code>Promise.&lt;Object&gt;</code>
+Retrieve a specific keyword
+
+**Kind**: static method of [<code>MobileKeyword</code>](#MobileKeyword)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - Promise of metadata  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| templateDir | <code>String</code> | Directory where retrieved metadata directory will be saved |
+| name | <code>String</code> | name of the metadata file |
+| templateVariables | <code>Object</code> | variables to be replaced in the metadata |
+
+<a name="MobileKeyword.create"></a>
+
+### MobileKeyword.create(MobileKeyword) ⇒ <code>Promise</code>
+Creates a single Event Definition
+
+**Kind**: static method of [<code>MobileKeyword</code>](#MobileKeyword)  
+**Returns**: <code>Promise</code> - Promise  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| MobileKeyword | <code>Object</code> | a single Event Definition |
+
+<a name="MobileKeyword.preDeployTasks"></a>
+
+### MobileKeyword.preDeployTasks(metadata) ⇒ <code>Promise</code>
+prepares an event definition for deployment
+
+**Kind**: static method of [<code>MobileKeyword</code>](#MobileKeyword)  
+**Returns**: <code>Promise</code> - Promise  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| metadata | <code>Object</code> | a single MobileKeyword |
+
 <a name="Query"></a>
 
 ## Query ⇐ [<code>MetadataType</code>](#MetadataType)
@@ -3223,6 +3467,7 @@ Query MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [Query](#Query) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Query.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#Query.retrieve) ⇒ <code>Promise.&lt;{metadata:QueryMap, type:string}&gt;</code>
     * [.retrieveForCache()](#Query.retrieveForCache) ⇒ <code>Promise.&lt;{metadata:QueryMap, type:string}&gt;</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#Query.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata:QueryMap, type:string}&gt;</code>
@@ -3233,6 +3478,10 @@ Query MetadataType
     * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName)](#Query.buildDefinitionForExtracts) ⇒ <code>Promise</code>
     * [.parseMetadata(metadata)](#Query.parseMetadata) ⇒ [<code>CodeExtractItem</code>](#CodeExtractItem)
 
+<a name="Query.client"></a>
+
+### Query.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Query</code>](#Query)  
 <a name="Query.retrieve"></a>
 
 ### Query.retrieve(retrieveDir) ⇒ <code>Promise.&lt;{metadata:QueryMap, type:string}&gt;</code>
@@ -3355,6 +3604,7 @@ ImportFile MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [Role](#Role) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Role.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir, _, buObject)](#Role.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.preDeployTasks(metadata)](#Role.preDeployTasks) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.create(metadata)](#Role.create) ⇒ <code>Promise</code>
@@ -3362,6 +3612,10 @@ ImportFile MetadataType
     * [.document(buObject, [metadata])](#Role.document) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._traverseRoles(role, element, [permission], [isAllowed])](#Role._traverseRoles) ⇒ <code>void</code>
 
+<a name="Role.client"></a>
+
+### Role.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Role</code>](#Role)  
 <a name="Role.retrieve"></a>
 
 ### Role.retrieve(retrieveDir, _, buObject) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -3448,6 +3702,7 @@ Script MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [Script](#Script) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#Script.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#Script.retrieve) ⇒ <code>Promise.&lt;{metadata:ScriptMap, type:string}&gt;</code>
     * [.retrieveForCache()](#Script.retrieveForCache) ⇒ <code>Promise.&lt;{metadata:ScriptMap, type:string}&gt;</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#Script.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata:ScriptMap, type:string}&gt;</code>
@@ -3459,6 +3714,10 @@ Script MetadataType
     * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName)](#Script.buildDefinitionForExtracts) ⇒ <code>Promise</code>
     * [.parseMetadata(metadata)](#Script.parseMetadata) ⇒ [<code>CodeExtractItem</code>](#CodeExtractItem)
 
+<a name="Script.client"></a>
+
+### Script.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>Script</code>](#Script)  
 <a name="Script.retrieve"></a>
 
 ### Script.retrieve(retrieveDir) ⇒ <code>Promise.&lt;{metadata:ScriptMap, type:string}&gt;</code>
@@ -3596,9 +3855,14 @@ SetDefinition MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [SetDefinition](#SetDefinition) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#SetDefinition.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#SetDefinition.retrieve) ⇒ <code>Promise</code>
     * [.retrieveForCache()](#SetDefinition.retrieveForCache) ⇒ <code>Promise</code>
 
+<a name="SetDefinition.client"></a>
+
+### SetDefinition.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>SetDefinition</code>](#SetDefinition)  
 <a name="SetDefinition.retrieve"></a>
 
 ### SetDefinition.retrieve(retrieveDir) ⇒ <code>Promise</code>
@@ -3627,13 +3891,19 @@ MessageSendActivity MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [TriggeredSendDefinition](#TriggeredSendDefinition) ⇐ [<code>MetadataType</code>](#MetadataType)
+    * [.client](#TriggeredSendDefinition.client) : <code>Util.SDK</code>
     * [.retrieve(retrieveDir)](#TriggeredSendDefinition.retrieve) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.create(metadata)](#TriggeredSendDefinition.create) ⇒ <code>Promise</code>
     * [.update(metadata)](#TriggeredSendDefinition.update) ⇒ <code>Promise</code>
+    * [.deleteByKey(buObject, customerKey)](#TriggeredSendDefinition.deleteByKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.postRetrieveTasks(metadata)](#TriggeredSendDefinition.postRetrieveTasks) ⇒ <code>Array.&lt;Object&gt;</code>
     * [.parseMetadata(metadata)](#TriggeredSendDefinition.parseMetadata) ⇒ <code>Array</code>
     * [.preDeployTasks(metadata)](#TriggeredSendDefinition.preDeployTasks) ⇒ <code>Object</code>
 
+<a name="TriggeredSendDefinition.client"></a>
+
+### TriggeredSendDefinition.client : <code>Util.SDK</code>
+**Kind**: static property of [<code>TriggeredSendDefinition</code>](#TriggeredSendDefinition)  
 <a name="TriggeredSendDefinition.retrieve"></a>
 
 ### TriggeredSendDefinition.retrieve(retrieveDir) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -3669,6 +3939,19 @@ Updates a single TSD.
 | Param | Type | Description |
 | --- | --- | --- |
 | metadata | <code>Object</code> | single metadata entry |
+
+<a name="TriggeredSendDefinition.deleteByKey"></a>
+
+### TriggeredSendDefinition.deleteByKey(buObject, customerKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
+Delete a metadata item from the specified business unit
+
+**Kind**: static method of [<code>TriggeredSendDefinition</code>](#TriggeredSendDefinition)  
+**Returns**: <code>Promise.&lt;boolean&gt;</code> - deletion success status  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| buObject | <code>Util.BuObject</code> | references credentials |
+| customerKey | <code>string</code> | Identifier of data extension |
 
 <a name="TriggeredSendDefinition.postRetrieveTasks"></a>
 
@@ -3715,7 +3998,7 @@ Retrieves metadata from a business unit and saves it to the local filesystem.
 
 * [Retriever](#Retriever)
     * [new Retriever(properties, buObject, client)](#new_Retriever_new)
-    * [.retrieve(metadataTypes, [name], [templateVariables], [changelogOnly])](#Retriever+retrieve) ⇒ <code>Promise.&lt;Object.&lt;string, Object&gt;&gt;</code>
+    * [.retrieve(metadataTypes, [name], [templateVariables], [changelogOnly])](#Retriever+retrieve) ⇒ <code>Promise.&lt;Util.MultiMetadataTypeList&gt;</code>
 
 <a name="new_Retriever_new"></a>
 
@@ -3738,11 +4021,11 @@ Creates a Retriever, uses v2 auth if v2AuthOptions are passed.
 
 <a name="Retriever+retrieve"></a>
 
-### retriever.retrieve(metadataTypes, [name], [templateVariables], [changelogOnly]) ⇒ <code>Promise.&lt;Object.&lt;string, Object&gt;&gt;</code>
+### retriever.retrieve(metadataTypes, [name], [templateVariables], [changelogOnly]) ⇒ <code>Promise.&lt;Util.MultiMetadataTypeList&gt;</code>
 Retrieve metadata of specified types into local file system and Retriever.metadata
 
 **Kind**: instance method of [<code>Retriever</code>](#Retriever)  
-**Returns**: <code>Promise.&lt;Object.&lt;string, Object&gt;&gt;</code> - Promise  
+**Returns**: <code>Promise.&lt;Util.MultiMetadataTypeList&gt;</code> - Promise of a list of retrieved items grouped by type {automation:[...], query:[...]}  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3777,6 +4060,7 @@ CLI entry for SFMC DevTools
     * [.getListPathNameFromCache(cache, searchValue, searchField)](#Util.getListPathNameFromCache) ⇒ <code>String</code>
     * [.retryOnError(errorMsg, callback, [silentError], [retries])](#Util.retryOnError) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.execSync(cmd, [args])](#Util.execSync) ⇒ <code>undefined</code>
+    * [.templateSearchResult(results, keyToSearch, searchValue)](#Util.templateSearchResult) ⇒ <code>MetadataTypeItem</code>
 
 <a name="Util.logger"></a>
 
@@ -3863,7 +4147,7 @@ key-value pairs (obj)
 | Param | Type | Description |
 | --- | --- | --- |
 | str | <code>String</code> \| <code>Object</code> | JSON object or its stringified version, which has values to be replaced |
-| obj | [<code>TemplateMap</code>](#TemplateMap) | key value object which contains keys to be replaced and values to be replaced with |
+| obj | <code>TemplateMap</code> | key value object which contains keys to be replaced and values to be replaced with |
 
 <a name="Util.inverseGet"></a>
 
@@ -3991,6 +4275,20 @@ helper to run other commands as if run manually by user
 | --- | --- | --- |
 | cmd | <code>string</code> | to be executed command |
 | [args] | <code>Array.&lt;string&gt;</code> | list of arguments |
+
+<a name="Util.templateSearchResult"></a>
+
+### Util.templateSearchResult(results, keyToSearch, searchValue) ⇒ <code>MetadataTypeItem</code>
+standardize check to ensure only one result is returned from template search
+
+**Kind**: static method of [<code>Util</code>](#Util)  
+**Returns**: <code>MetadataTypeItem</code> - metadata to be used in building template  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| results | <code>Array.&lt;MetadataTypeItem&gt;</code> | array of metadata |
+| keyToSearch | <code>string</code> | the field which contains the searched value |
+| searchValue | <code>string</code> | the value which is being looked for |
 
 <a name="MetadataTypeDefinitions"></a>
 
@@ -4222,17 +4520,17 @@ DevOps helper class
 **Kind**: global constant  
 
 * [DevOps](#DevOps)
-    * [.createDeltaPkg(properties, [range], [saveToDeployDir], [filterPaths])](#DevOps.createDeltaPkg) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.createDeltaPkg(properties, [range], [saveToDeployDir], [filterPaths])](#DevOps.createDeltaPkg) ⇒ <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code>
     * [.document(directory, jsonReport)](#DevOps.document) ⇒ <code>void</code>
 
 <a name="DevOps.createDeltaPkg"></a>
 
-### DevOps.createDeltaPkg(properties, [range], [saveToDeployDir], [filterPaths]) ⇒ <code>Promise.&lt;Object&gt;</code>
+### DevOps.createDeltaPkg(properties, [range], [saveToDeployDir], [filterPaths]) ⇒ <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code>
 Extracts the delta between a commit and the current state for deployment.
 Interactive commit selection if no commits are passed.
 
 **Kind**: static method of [<code>DevOps</code>](#DevOps)  
-**Returns**: <code>Promise.&lt;Object&gt;</code> - -  
+**Returns**: <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code> - -  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -5391,6 +5689,7 @@ Util that contains logger and simple util methods
     * [.getListPathNameFromCache(cache, searchValue, searchField)](#Util.getListPathNameFromCache) ⇒ <code>String</code>
     * [.retryOnError(errorMsg, callback, [silentError], [retries])](#Util.retryOnError) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.execSync(cmd, [args])](#Util.execSync) ⇒ <code>undefined</code>
+    * [.templateSearchResult(results, keyToSearch, searchValue)](#Util.templateSearchResult) ⇒ <code>MetadataTypeItem</code>
 
 <a name="Util.logger"></a>
 
@@ -5477,7 +5776,7 @@ key-value pairs (obj)
 | Param | Type | Description |
 | --- | --- | --- |
 | str | <code>String</code> \| <code>Object</code> | JSON object or its stringified version, which has values to be replaced |
-| obj | [<code>TemplateMap</code>](#TemplateMap) | key value object which contains keys to be replaced and values to be replaced with |
+| obj | <code>TemplateMap</code> | key value object which contains keys to be replaced and values to be replaced with |
 
 <a name="Util.inverseGet"></a>
 
@@ -5605,6 +5904,20 @@ helper to run other commands as if run manually by user
 | --- | --- | --- |
 | cmd | <code>string</code> | to be executed command |
 | [args] | <code>Array.&lt;string&gt;</code> | list of arguments |
+
+<a name="Util.templateSearchResult"></a>
+
+### Util.templateSearchResult(results, keyToSearch, searchValue) ⇒ <code>MetadataTypeItem</code>
+standardize check to ensure only one result is returned from template search
+
+**Kind**: static method of [<code>Util</code>](#Util)  
+**Returns**: <code>MetadataTypeItem</code> - metadata to be used in building template  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| results | <code>Array.&lt;MetadataTypeItem&gt;</code> | array of metadata |
+| keyToSearch | <code>string</code> | the field which contains the searched value |
+| searchValue | <code>string</code> | the value which is being looked for |
 
 <a name="getUserName"></a>
 
@@ -5762,16 +6075,16 @@ REST format
 | FieldType | <code>&#x27;Text&#x27;</code> \| <code>&#x27;Number&#x27;</code> \| <code>&#x27;Date&#x27;</code> \| <code>&#x27;Boolean&#x27;</code> \| <code>&#x27;Decimal&#x27;</code> \| <code>&#x27;EmailAddress&#x27;</code> \| <code>&#x27;Phone&#x27;</code> \| <code>&#x27;Locale&#x27;</code> | can only be set on create |
 | Scale | <code>string</code> | the number of places after the decimal that the field can hold; example: "0","1", ... |
 
-<a name="MultiMetadataTypeMap"></a>
+<a name="CodeExtract"></a>
 
-## MultiMetadataTypeMap : <code>Object.&lt;string, any&gt;</code>
+## CodeExtract : <code>Object</code>
 **Kind**: global typedef  
 **Properties**
 
 | Name | Type | Description |
 | --- | --- | --- |
-| json | <code>MetadataTypeItem</code> | metadata of one item w/o code |
-| codeArr | <code>Array.&lt;CodeExtract&gt;</code> | list of code snippets in this item |
+| json | <code>Util.MetadataTypeItem</code> | metadata of one item w/o code |
+| codeArr | [<code>Array.&lt;CodeExtract&gt;</code>](#CodeExtract) | list of code snippets in this item |
 | subFolder | <code>Array.&lt;string&gt;</code> | mostly set to null, otherwise list of subfolders |
 | subFolder | <code>Array.&lt;string&gt;</code> | mostly set to null, otherwise subfolders path split into elements |
 | fileName | <code>string</code> | name of file w/o extension |
@@ -5825,7 +6138,7 @@ REST format
 | codeArr | <code>Array.&lt;MetadataType.CodeExtract&gt;</code> | list of code snippets in this item |
 | subFolder | <code>Array.&lt;string&gt;</code> | mostly set to null, otherwise list of subfolders |
 
-<a name="TemplateMap"></a>
+<a name="MultiMetadataTypeList"></a>
 
-## TemplateMap : <code>Object.&lt;string, string&gt;</code>
+## MultiMetadataTypeList : <code>Object.&lt;string, string&gt;</code>
 **Kind**: global typedef  

--- a/lib/Retriever.js
+++ b/lib/Retriever.js
@@ -41,9 +41,12 @@ class Retriever {
      * @param {String} [name] name of Metadata to retrieve (in case of templating)
      * @param {Object} [templateVariables] Object of values which can be replaced (in case of templating)
      * @param {boolean} [changelogOnly] skip saving, only create json in memory
-     * @returns {Promise<Object<string,Object>>} Promise
+     * @returns {Promise<Util.MultiMetadataTypeList>} Promise of a list of retrieved items grouped by type {automation:[...], query:[...]}
      */
     async retrieve(metadataTypes, name, templateVariables, changelogOnly) {
+        /**
+         * @type {Util.MultiMetadataTypeList}
+         */
         const retrieveChangelog = {};
         for (const metadataType of Util.getMetadataHierachy(metadataTypes)) {
             let result;

--- a/lib/Retriever.js
+++ b/lib/Retriever.js
@@ -127,9 +127,9 @@ class Retriever {
                         this.metadata[type] = result.map((element) => element.metadata);
                     } else {
                         this.metadata[type] = result.metadata;
-                        if (metadataTypes.includes(type) || metadataTypes.includes(metadataType)) {
-                            retrieveChangelog[type] = result.metadata;
-                        }
+                    }
+                    if (metadataTypes.includes(type) || metadataTypes.includes(metadataType)) {
+                        retrieveChangelog[type] = this.metadata[type];
                     }
                 }
             } catch (ex) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -735,7 +735,7 @@ class Mcdev {
      * @param {String} selectedType supported metadata type
      * @param {String} name name of the metadata
      * @param {String} market market which should be used to revert template
-     * @returns {Promise<void>} -
+     * @returns {Promise<Util.MultiMetadataTypeList>} -
      */
     static async retrieveAsTemplate(businessUnit, selectedType, name, market) {
         Util.logger.info('mcdev:: Retrieve as Template');

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,11 +118,6 @@ class Mcdev {
                             buTypeDelta[buPath][file.type] = [];
                         }
                         buTypeDelta[buPath][file.type].push(file.name);
-
-                        if (!typeDelta[file.type]) {
-                            typeDelta[file.type] = [];
-                        }
-                        typeDelta[file.type].push(file.name);
                     });
 
                 // Run retrieve as template for each business unit for each type
@@ -135,12 +130,21 @@ class Mcdev {
                                 ','
                             )}" ${sourceMarket}`
                         );
-                        await this.retrieveAsTemplate(
+                        const result = await this.retrieveAsTemplate(
                             bu,
                             type,
                             buTypeDelta[bu][type].join(','),
                             sourceMarket
                         );
+
+                        // ensure we have the right key for bd/bdb that matches the name used for rt
+                        const keys = result[type].map(
+                            (item) => item[MetadataTypeInfo[type].definition.keyField]
+                        );
+                        if (!typeDelta[type]) {
+                            typeDelta[type] = [];
+                        }
+                        typeDelta[type].push(...keys);
                     }
                 }
 

--- a/lib/metadataTypes/Automation.js
+++ b/lib/metadataTypes/Automation.js
@@ -192,7 +192,7 @@ class Automation extends MetadataType {
         });
         if (results && Array.isArray(results.Results)) {
             // eq-operator returns a similar, not exact match and hence might return more than 1 entry
-            const [metadata] = results.filter((item) => item.Name === name);
+            const [metadata] = results.Results.filter((item) => item.Name === name);
             if (!metadata) {
                 Util.logger.error(`${this.definition.type} '${name}' not found on server.`);
                 return;

--- a/lib/metadataTypes/MetadataType.js
+++ b/lib/metadataTypes/MetadataType.js
@@ -8,10 +8,8 @@
  */
 
 /**
- * @typedef {Object.<string, any>} MetadataTypeItem
- *
  * @typedef {Object} CodeExtractItem
- * @property {MetadataTypeItem} json metadata of one item w/o code
+ * @property {Util.MetadataTypeItem} json metadata of one item w/o code
  * @property {CodeExtract[]} codeArr list of code snippets in this item
  * @property {string[]} subFolder mostly set to null, otherwise list of subfolders
  *
@@ -22,10 +20,6 @@
  * @property {string} content file content
  * @property {'base64'} [encoding] optional for binary files
 
- *
- * @typedef {Object.<string, MetadataTypeItem>} MetadataTypeMap
- *
- * @typedef {Object.<string, MetadataTypeMap>} MultiMetadataTypeMap
  */
 
 const Util = require('../util/util');
@@ -132,7 +126,7 @@ class MetadataType {
 
     /**
      * Deploys metadata
-     * @param {MetadataTypeMap} metadata metadata mapped by their keyField
+     * @param {Util.MetadataTypeMap} metadata metadata mapped by their keyField
      * @param {string} deployDir directory where deploy metadata are saved
      * @param {string} retrieveDir directory where metadata after deploy should be saved
      * @param {Util.BuObject} buObject properties for auth
@@ -151,25 +145,25 @@ class MetadataType {
 
     /**
      * Gets executed after deployment of metadata type
-     * @param {MetadataTypeMap} metadata metadata mapped by their keyField
-     * @param {MetadataTypeMap} originalMetadata metadata to be updated (contains additioanl fields)
+     * @param {Util.MetadataTypeMap} metadata metadata mapped by their keyField
+     * @param {Util.MetadataTypeMap} originalMetadata metadata to be updated (contains additioanl fields)
      * @returns {void}
      */
     static postDeployTasks(metadata, originalMetadata) {}
 
     /**
      * Gets executed after retreive of metadata type
-     * @param {MetadataTypeItem} metadata a single item
+     * @param {Util.MetadataTypeItem} metadata a single item
      * @param {string} targetDir folder where retrieves should be saved
      * @param {boolean} [isTemplating] signals that we are retrieving templates
-     * @returns {MetadataTypeItem} cloned metadata
+     * @returns {Util.MetadataTypeItem} cloned metadata
      */
     static postRetrieveTasks(metadata, targetDir, isTemplating) {
         return JSON.parse(JSON.stringify(metadata));
     }
     /**
      * used to synchronize name and external key during retrieveAsTemplate
-     * @param {MetadataTypeItem} metadata a single item
+     * @param {Util.MetadataTypeItem} metadata a single item
      * @param {string} [warningMsg] optional msg to show the user
      * @returns {void}
      */
@@ -197,7 +191,7 @@ class MetadataType {
      * @param {string[]} [additionalFields] Returns specified fields even if their retrieve definition is not set to true
      * @param {Util.BuObject} buObject properties for auth
      * @param {string} [subType] optionally limit to a single subtype
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} metadata
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} metadata
      */
     static retrieve(retrieveDir, additionalFields, buObject, subType) {
         Util.metadataLogger('error', this.definition.type, 'retrieve', `Not Supported`);
@@ -209,7 +203,7 @@ class MetadataType {
      * @param {string[]} [additionalFields] Returns specified fields even if their retrieve definition is not set to true
      * @param {Util.BuObject} buObject properties for auth
      * @param {string} [subType] optionally limit to a single subtype
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} metadata
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} metadata
      */
     static retrieveChangelog(additionalFields, buObject, subType) {
         return this.retrieve(null, additionalFields, buObject, subType);
@@ -219,7 +213,7 @@ class MetadataType {
      * Gets metadata cache with limited fields and does not store value to disk
      * @param {Util.BuObject} buObject properties for auth
      * @param {string} [subType] optionally limit to a single subtype
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} metadata
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} metadata
      */
     static async retrieveForCache(buObject, subType) {
         return this.retrieve(null, null, buObject, subType);
@@ -230,7 +224,7 @@ class MetadataType {
      * @param {string} name name of the metadata file
      * @param {Util.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} [subType] optionally limit to a single subtype
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} metadata
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} metadata
      */
     static retrieveAsTemplate(templateDir, name, templateVariables, subType) {
         Util.logger.error('retrieveAsTemplate is not supported yet for ' + this.definition.type);
@@ -245,9 +239,9 @@ class MetadataType {
 
     /**
      * Gets executed before deploying metadata
-     * @param {MetadataTypeItem} metadata a single metadata item
+     * @param {Util.MetadataTypeItem} metadata a single metadata item
      * @param {string} deployDir folder where files for deployment are stored
-     * @returns {Promise<MetadataTypeItem>} Promise of a single metadata item
+     * @returns {Promise<Util.MetadataTypeItem>} Promise of a single metadata item
      */
     static async preDeployTasks(metadata, deployDir) {
         return metadata;
@@ -255,7 +249,7 @@ class MetadataType {
 
     /**
      * Abstract create method that needs to be implemented in child metadata type
-     * @param {MetadataTypeItem} metadata single metadata entry
+     * @param {Util.MetadataTypeItem} metadata single metadata entry
      * @param {string} deployDir directory where deploy metadata are saved
      * @returns {void}
      */
@@ -266,8 +260,8 @@ class MetadataType {
 
     /**
      * Abstract update method that needs to be implemented in child metadata type
-     * @param {MetadataTypeItem} metadata single metadata entry
-     * @param {MetadataTypeItem} [metadataBefore] metadata mapped by their keyField
+     * @param {Util.MetadataTypeItem} metadata single metadata entry
+     * @param {Util.MetadataTypeItem} [metadataBefore] metadata mapped by their keyField
      * @returns {void}
      */
     static update(metadata, metadataBefore) {
@@ -277,10 +271,10 @@ class MetadataType {
 
     /**
      * MetadataType upsert, after retrieving from target and comparing to check if create or update operation is needed.
-     * @param {MetadataTypeMap} metadata metadata mapped by their keyField
+     * @param {Util.MetadataTypeMap} metadata metadata mapped by their keyField
      * @param {string} deployDir directory where deploy metadata are saved
      * @param {Util.BuObject} [buObject] properties for auth
-     * @returns {Promise<MetadataTypeMap>} keyField => metadata map
+     * @returns {Promise<Util.MetadataTypeMap>} keyField => metadata map
      */
     static async upsert(metadata, deployDir, buObject) {
         const metadataToUpdate = [];
@@ -379,7 +373,7 @@ class MetadataType {
 
     /**
      * Creates a single metadata entry via REST
-     * @param {MetadataTypeItem} metadataEntry a single metadata Entry
+     * @param {Util.MetadataTypeItem} metadataEntry a single metadata Entry
      * @param {string} uri rest endpoint for POST
      * @returns {Promise} Promise
      */
@@ -409,7 +403,7 @@ class MetadataType {
 
     /**
      * Creates a single metadata entry via fuel-soap (generic lib not wrapper)
-     * @param {MetadataTypeItem} metadataEntry single metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry single metadata entry
      * @param {string} [overrideType] can be used if the API type differs from the otherwise used type identifier
      * @param {boolean} [handleOutside] if the API reponse is irregular this allows you to handle it outside of this generic method
      * @returns {Promise} Promise
@@ -459,7 +453,7 @@ class MetadataType {
 
     /**
      * Updates a single metadata entry via REST
-     * @param {MetadataTypeItem} metadataEntry a single metadata Entry
+     * @param {Util.MetadataTypeItem} metadataEntry a single metadata Entry
      * @param {string} uri rest endpoint for PATCH
      * @returns {Promise} Promise
      */
@@ -493,7 +487,7 @@ class MetadataType {
 
     /**
      * Updates a single metadata entry via fuel-soap (generic lib not wrapper)
-     * @param {MetadataTypeItem} metadataEntry single metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry single metadata entry
      * @param {string} [overrideType] can be used if the API type differs from the otherwise used type identifier
      * @param {boolean} [handleOutside] if the API reponse is irregular this allows you to handle it outside of this generic method
      * @returns {Promise} Promise
@@ -547,7 +541,7 @@ class MetadataType {
      * @param {Object} [requestParams] required for the specific request (filter for example)
      * @param {string[]} [additionalFields] Returns specified fields even if their retrieve definition is not set to true
      * @param {string} [overrideType] can be used if the API type differs from the otherwise used type identifier
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} Promise of item map
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} Promise of item map
      */
     static async retrieveSOAPgeneric(
         retrieveDir,
@@ -578,7 +572,7 @@ class MetadataType {
      * @param {string[]} fields list of fields that we want to see retrieved
      * @param {Object} [options] required for the specific request (filter for example)
      * @param {string} [type] optionally overwrite the API type of the metadata here
-     * @returns {Promise<MetadataTypeMap>} keyField => metadata map
+     * @returns {Promise<Util.MetadataTypeMap>} keyField => metadata map
      */
     static async retrieveSOAPBody(fields, options, type) {
         let status;
@@ -619,7 +613,7 @@ class MetadataType {
      * @param {string} uri rest endpoint for GET
      * @param {string} [overrideType] force a metadata type (mainly used for Folders)
      * @param {Util.TemplateMap} [templateVariables] variables to be replaced in the metadata
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} Promise of item map
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} Promise of item map
      */
     static async retrieveREST(retrieveDir, uri, overrideType, templateVariables) {
         let response;
@@ -661,7 +655,7 @@ class MetadataType {
     /**
      * Builds map of metadata entries mapped to their keyfields
      * @param {Object} body json of response body
-     * @returns {Promise<MetadataTypeMap>} keyField => metadata map
+     * @returns {Promise<Util.MetadataTypeMap>} keyField => metadata map
      */
     static parseResponseBody(body) {
         const bodyIteratorField = this.definition.bodyIteratorField;
@@ -690,7 +684,7 @@ class MetadataType {
      * @example
      * Removes field (or nested fields childs) that are not updateable
      * deleteFieldByDefinition(metadataEntry, 'CustomerKey', 'isUpdateable');
-     * @param {MetadataTypeItem} metadataEntry One entry of a metadataType
+     * @param {Util.MetadataTypeItem} metadataEntry One entry of a metadataType
      * @param {string} fieldPath field path to be checked if it conforms to the definition (dot seperated if nested): 'fuu.bar'
      * @param {'isCreateable'|'isUpdateable'|'retrieving'|'templating'} definitionProperty delete field if definitionProperty equals false for specified field. Options: [isCreateable | isUpdateable]
      * @param {string} origin string of parent object, required when using arrays as these are parsed slightly differently.
@@ -772,7 +766,7 @@ class MetadataType {
     }
     /**
      * Remove fields from metadata entry that are not createable
-     * @param {MetadataTypeItem} metadataEntry metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry metadata entry
      * @returns {void}
      */
     static removeNotCreateableFields(metadataEntry) {
@@ -783,7 +777,7 @@ class MetadataType {
 
     /**
      * Remove fields from metadata entry that are not updateable
-     * @param {MetadataTypeItem} metadataEntry metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry metadata entry
      * @returns {void}
      */
     static removeNotUpdateableFields(metadataEntry) {
@@ -794,7 +788,7 @@ class MetadataType {
 
     /**
      * Remove fields from metadata entry that are not needed in the template
-     * @param {MetadataTypeItem} metadataEntry metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry metadata entry
      * @returns {void}
      */
     static keepTemplateFields(metadataEntry) {
@@ -805,7 +799,7 @@ class MetadataType {
 
     /**
      * Remove fields from metadata entry that are not needed in the stored metadata
-     * @param {MetadataTypeItem} metadataEntry metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry metadata entry
      * @returns {void}
      */
     static keepRetrieveFields(metadataEntry) {
@@ -817,7 +811,7 @@ class MetadataType {
     /**
      * checks if the current metadata entry should be saved on retrieve or not
      * @static
-     * @param {MetadataTypeItem} metadataEntry metadata entry
+     * @param {Util.MetadataTypeItem} metadataEntry metadata entry
      * @param {boolean} [include=false] true: use definition.include / options.include; false=exclude: use definition.filter / options.exclude
      * @returns {boolean} true: skip saving == filtered; false: continue with saving
      * @memberof MetadataType
@@ -988,11 +982,11 @@ class MetadataType {
 
     /**
      * Helper for writing Metadata to disk, used for Retrieve and deploy
-     * @param {MetadataTypeMap} results metadata results from deploy
+     * @param {Util.MetadataTypeMap} results metadata results from deploy
      * @param {string} retrieveDir directory where metadata should be stored after deploy/retrieve
      * @param {string} [overrideType] for use when there is a subtype (such as folder-queries)
      * @param {Util.TemplateMap} [templateVariables] variables to be replaced in the metadata
-     * @returns {Promise<MetadataTypeMap>} Promise of saved metadata
+     * @returns {Promise<Util.MetadataTypeMap>} Promise of saved metadata
      */
     static async saveResults(results, retrieveDir, overrideType, templateVariables) {
         const savedResults = {};
@@ -1119,7 +1113,7 @@ class MetadataType {
      * handles extracted code if any are found for complex types (e.g script, asset, query)
      * @param {string} templateDir Directory where metadata templates are stored
      * @param {string} targetDir Directory where built definitions will be saved
-     * @param {MetadataTypeItem} metadata main JSON file that was read from file system
+     * @param {Util.MetadataTypeItem} metadata main JSON file that was read from file system
      * @param {Util.TemplateMap} variables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
      * @returns {Promise<void>} Promise
@@ -1164,7 +1158,7 @@ class MetadataType {
      * @param {String|String[]} targetDir (List of) Directory where built definitions will be saved
      * @param {string} templateName name of the metadata file
      * @param {Util.TemplateMap} variables variables to be replaced in the metadata
-     * @returns {Promise<{metadata:MetadataTypeMap,type:string}>} Promise of item map
+     * @returns {Promise<{metadata:Util.MetadataTypeMap,type:string}>} Promise of item map
      */
     static async buildDefinition(templateDir, targetDir, templateName, variables) {
         // retrieve metadata template
@@ -1282,7 +1276,7 @@ class MetadataType {
     /**
      * Gets metadata cache with limited fields and does not store value to disk
      * @param {Util.BuObject} [buObject] properties for auth
-     * @param {MetadataTypeMap} [metadata] a list of type definitions
+     * @param {Util.MetadataTypeMap} [metadata] a list of type definitions
      * @param {boolean} [isDeploy] used to skip non-supported message during deploy
      * @returns {void}
      */
@@ -1406,7 +1400,7 @@ MetadataType.definition = {
  */
 MetadataType.client = undefined;
 /**
- * @type {MultiMetadataTypeMap}
+ * @type {Util.MultiMetadataTypeMap}
  */
 MetadataType.cache = {};
 MetadataType.properties = null;

--- a/lib/util/devops.js
+++ b/lib/util/devops.js
@@ -17,7 +17,7 @@ const DevOps = {
      * @param {String} [range] git commit range
      * @param {boolean} [saveToDeployDir] if true, copy metadata changes into deploy directory
      * @param {String} [filterPaths] filter file paths that start with any specified path (comma separated)
-     * @returns {Promise<Object>} -
+     * @returns {Promise<Object[]>} -
      */
     async createDeltaPkg(properties, range, saveToDeployDir, filterPaths) {
         const rangeUserInput = range;

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -14,6 +14,14 @@
  */
 /**
  * @typedef {Object.<string,string>} TemplateMap
+ *
+ * @typedef {Object.<string, any>} MetadataTypeItem
+ *
+ * @typedef {Object.<string, MetadataTypeItem>} MetadataTypeMap
+ *
+ * @typedef {Object.<string, MetadataTypeMap>} MultiMetadataTypeMap
+ *
+ * @typedef {Object.<string, MetadataTypeItem[]>} MultiMetadataTypeList
  */
 
 /** @type SDK */


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [x] Bugfix

## What changes did you make? (Give an overview)

**high priority bugfix for client demo!** 
- fixes #187 

inside of `createDeltaPkg` after running `retrieveAsTemplate` we gather the keys for the new templates and hand them over to `buildDefinitionBuild`. Before, both methods tried using the same value which had to be the name because that's what `rt` needed.

## Is there anything you'd like reviewers to focus on?

I moved the JSDoc definition from MetadataType.js to Util.js, enabling us to do what we talked about the other day but then couldn't. 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
- [ ] README.md updated (if applicable)
- [ ] CHANGELOG.md updated
- [x] ran `npm run docs` to update developer docs
