### PR TITLE
#222 improved debug output for callouts

### DIFF
--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -91,9 +91,10 @@ class Builder {
             }
         } catch (ex) {
             Util.logger.error('mcdev.buildDefinition:' + ex.message);
-            Util.logger.debug(ex.stack);
+            const stack = new Error().stack;
+            Util.logger.debug(ex.message + ' ' + stack);
             if (Util.logger.level === 'debug') {
-                console.log(ex.stack);
+                console.log(ex.message, stack);
             }
         }
         return this.metadata;

--- a/lib/Retriever.js
+++ b/lib/Retriever.js
@@ -127,9 +127,10 @@ class Retriever {
                 }
             } catch (ex) {
                 Util.logger.error(`Retriever.retrieve:: Retrieving ${metadataType} failed`);
-                Util.logger.debug(ex.stack);
+                const stack = new Error().stack;
+                Util.logger.debug(ex.message + ' ' + stack);
                 if (Util.logger.level === 'debug') {
-                    console.log(ex.stack);
+                    console.log(ex.message, stack);
                 }
             }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -453,9 +453,10 @@ class Mcdev {
                 }
             } catch (ex) {
                 Util.logger.error('mcdev.retrieve failed: ' + ex.message);
-                Util.logger.debug(ex.stack);
+                const stack = new Error().stack;
+                Util.logger.debug(ex.message + ' ' + stack);
                 if (Util.logger.level === 'debug') {
-                    console.log(ex.stack);
+                    console.log(ex.message, stack);
                 }
             }
         }
@@ -487,9 +488,10 @@ class Mcdev {
                 await deployer.deploy();
             } catch (ex) {
                 Util.logger.error('mcdev.deploy failed: ' + ex.message);
-                Util.logger.debug(ex.stack);
+                const stack = new Error().stack;
+                Util.logger.debug(ex.message + ' ' + stack);
                 if (Util.logger.level === 'debug') {
-                    console.log(ex.stack);
+                    console.log(ex.message, stack);
                 }
             }
         }

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -491,12 +491,18 @@ const Util = {
                     authObject.scope = authObject.scope.split(' '); // Scope is usually not an array, but we enforce conversion here for simplicity
                     credentialStore.set(credentialKey, authObject);
                 },
-                onConnectionError: (ex, remainingAttempts) =>
+                onConnectionError: (ex, remainingAttempts) => {
                     Util.logger.warn(
                         `Connection problem (Code: ${ex.code}). Retrying ${remainingAttempts} time${
                             remainingAttempts > 1 ? 's' : ''
                         }`
-                    ),
+                    );
+                    const stack = new Error().stack;
+                    Util.logger.debug(ex.message + ' ' + stack);
+                    if (Util.logger.level === 'debug') {
+                        console.log(ex.message, stack);
+                    }
+                },
             },
             requestAttempts: 4,
             retryOnConnectionError: true,


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

_Please delete options that are not relevant._

- [x] Other, please explain:

fixes #222 

## What changes did you make? (Give an overview)

In certain cases we wanted a stack trace in our logs our CLI output. this was so far using Error.stack but as depicted in the issue, that's weirdly not always the best way. Instead, creating a NEW error and using that error's stack tends to do the trick of showing the full stack.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
- [n/a] README.md updated (if applicable)
- [n/a] CHANGELOG.md updated
- [n/a] ran `npm run docs` to update developer docs
