### PR TITLE
Feature/stop retrieve on exception

### DIFF
--- a/lib/Retriever.js
+++ b/lib/Retriever.js
@@ -127,6 +127,8 @@ class Retriever {
                 }
             } catch (ex) {
                 Util.logger.errorStack(ex, `Retrieving ${metadataType} failed`);
+                // do not continue retrieving if one type failed. simply skip processing the rest of the for-loop
+                break;
             }
         }
         return retrieveChangelog;


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [x] Other, please explain:

## What changes did you make? (Give an overview)

before, the retrieve would simply skip to the next type after one failed to load. now it should stop loading.
![image](https://user-images.githubusercontent.com/1917227/160936013-beacc80b-92e4-4e69-ae0d-7ebd7ea8d080.png)

**Close PRs with lower ID first!**

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
- [n/a] README.md updated (if applicable)
- [n/a] ran `npm run docs` to update developer docs
