### PR TITLE
Breaking Change: #244 option to document of standard roles (default: off) + `document`  parameters order changed to mirror other commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ The central config in `.mcdevrc.json` holds multiple adjustable settings:
       }
     },
     "documentType": "md",
+    "documentStandardRoles": true,
     "exclude": {
       "role": {
         "CustomerKey": ["excludedRoleKey","excludedOtherRoleKey"]
@@ -1022,6 +1023,7 @@ The central config in `.mcdevrc.json` holds multiple adjustable settings:
 | options.deployment.sourceTargetMapping   | `{"deployment-source": "deployment-target"}` | Configuration of 1 or many source-target marketList combos for `mcdev createDeltaPkg`                                       |
 | options.deployment.targetBranchBuMapping | `{"release/*": "...","master": ["..."]}`     | Can be used by CI/CD pipelines to know what BUs shall be deployed to upon a merge into one of the specified branches        |
 | options.documentType                     | 'md'                                         | Defines the format for documentation ('md', 'html', 'both')                                                                 |
+| options.documentStandardRoles            | true                                         | Optionally skip standard role documentation by setting to false                                                         |
 | options.exclude.`type`.`field`           | []                                           | Allows you to filter out metadata on retrieve based on their field values, e.g. CustomerKey (previously `options.filter`)   |
 | options.include.`type`.`field`           | []                                           | Allows you to filter out metadata on retrieve based on their field values, e.g. CustomerKey                                 |
 | options.serverTimeOffset                 | -6                                           | Used to work around quirks in how SFMC handles timezones; For stack4: set to -7 (US Mountain time); others: -6 (US Central) |

--- a/README.md
+++ b/README.md
@@ -530,13 +530,15 @@ mcdev badKeys MyProject/DEV
 
 <a id="markdown-document" name="document"></a>
 
-_Command:_ `mcdev document <TYPE> <business unit>`
+_Command:_ `mcdev document <business unit> <TYPE>`
 
 _Alias:_ `mcdev doc`
 
 Creates human readable documentation for your metadata. This command is executed by default unless you changed your config manually to set `options.documentOnRetrieve : false`. Therefore, running it manually is typically not required. You can choose to generate **HTML** (`html`) or **Markdown** (`md`) docs via `options.documentType`.
 
 The default format is set to `md` as Markdown renders nicely in Git as well as in VSCode's Markdown preview and can be copied from there into Confluence and other applications without losing the formatting.
+
+As standard roles are often not used by projects, we have the optional setting `options.documentStandardRoles` which is by default set to false
 
 Currently supported types:
 
@@ -549,7 +551,7 @@ Currently supported types:
 _Example:_
 
 ```bash
-mcdev document role myServer
+mcdev document myServer role
 ```
 
 #### 6.1.6. selectTypes
@@ -1023,7 +1025,7 @@ The central config in `.mcdevrc.json` holds multiple adjustable settings:
 | options.deployment.sourceTargetMapping   | `{"deployment-source": "deployment-target"}` | Configuration of 1 or many source-target marketList combos for `mcdev createDeltaPkg`                                       |
 | options.deployment.targetBranchBuMapping | `{"release/*": "...","master": ["..."]}`     | Can be used by CI/CD pipelines to know what BUs shall be deployed to upon a merge into one of the specified branches        |
 | options.documentType                     | 'md'                                         | Defines the format for documentation ('md', 'html', 'both')                                                                 |
-| options.documentStandardRoles            | true                                         | Optionally skip standard role documentation by setting to false                                                         |
+| options.documentStandardRoles            | false                                         | Optionally skip standard role documentation by setting to false                                                         |
 | options.exclude.`type`.`field`           | []                                           | Allows you to filter out metadata on retrieve based on their field values, e.g. CustomerKey (previously `options.filter`)   |
 | options.include.`type`.`field`           | []                                           | Allows you to filter out metadata on retrieve based on their field values, e.g. CustomerKey                                 |
 | options.serverTimeOffset                 | -6                                           | Used to work around quirks in how SFMC handles timezones; For stack4: set to -7 (US Mountain time); others: -6 (US Central) |

--- a/boilerplate/config.json
+++ b/boilerplate/config.json
@@ -20,6 +20,7 @@
             }
         },
         "documentType": "md",
+        "documentStandardRoles": false,
         "exclude": {},
         "include": {},
         "serverTimeOffset": -6

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -2684,8 +2684,7 @@ Provides default functionality that can be overwritten by child metadata type cl
     * [.createSOAP(metadataEntry, [overrideType], [handleOutside])](#MetadataType.createSOAP) ⇒ <code>Promise</code>
     * [.updateREST(metadataEntry, uri)](#MetadataType.updateREST) ⇒ <code>Promise</code>
     * [.updateSOAP(metadataEntry, [overrideType], [handleOutside])](#MetadataType.updateSOAP) ⇒ <code>Promise</code>
-    * [.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType])](#MetadataType.retrieveSOAPgeneric) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
-    * [.retrieveSOAPBody(fields, [options], [type])](#MetadataType.retrieveSOAPBody) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
+    * [.retrieveSOAP(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType])](#MetadataType.retrieveSOAP) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
     * [.retrieveREST(retrieveDir, uri, [overrideType], [templateVariables])](#MetadataType.retrieveREST) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
     * [.parseResponseBody(body)](#MetadataType.parseResponseBody) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
     * [.deleteFieldByDefinition(metadataEntry, fieldPath, definitionProperty, origin)](#MetadataType.deleteFieldByDefinition) ⇒ <code>void</code>
@@ -2963,9 +2962,9 @@ Updates a single metadata entry via fuel-soap (generic lib not wrapper)
 | [overrideType] | <code>string</code> | can be used if the API type differs from the otherwise used type identifier |
 | [handleOutside] | <code>boolean</code> | if the API reponse is irregular this allows you to handle it outside of this generic method |
 
-<a name="MetadataType.retrieveSOAPgeneric"></a>
+<a name="MetadataType.retrieveSOAP"></a>
 
-### MetadataType.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveSOAP(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Retrieves SOAP via generic fuel-soap wrapper based metadata of metadata type into local filesystem. executes callback with retrieved metadata
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
@@ -2978,20 +2977,6 @@ Retrieves SOAP via generic fuel-soap wrapper based metadata of metadata type int
 | [requestParams] | <code>Object</code> | required for the specific request (filter for example) |
 | [additionalFields] | <code>Array.&lt;string&gt;</code> | Returns specified fields even if their retrieve definition is not set to true |
 | [overrideType] | <code>string</code> | can be used if the API type differs from the otherwise used type identifier |
-
-<a name="MetadataType.retrieveSOAPBody"></a>
-
-### MetadataType.retrieveSOAPBody(fields, [options], [type]) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
-helper that handles batched retrieve via SOAP
-
-**Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;Util.MetadataTypeMap&gt;</code> - keyField => metadata map  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fields | <code>Array.&lt;string&gt;</code> | list of fields that we want to see retrieved |
-| [options] | <code>Object</code> | required for the specific request (filter for example) |
-| [type] | <code>string</code> | optionally overwrite the API type of the metadata here |
 
 <a name="MetadataType.retrieveREST"></a>
 
@@ -5924,8 +5909,7 @@ REST format
     * [.createSOAP(metadataEntry, [overrideType], [handleOutside])](#MetadataType.createSOAP) ⇒ <code>Promise</code>
     * [.updateREST(metadataEntry, uri)](#MetadataType.updateREST) ⇒ <code>Promise</code>
     * [.updateSOAP(metadataEntry, [overrideType], [handleOutside])](#MetadataType.updateSOAP) ⇒ <code>Promise</code>
-    * [.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType])](#MetadataType.retrieveSOAPgeneric) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
-    * [.retrieveSOAPBody(fields, [options], [type])](#MetadataType.retrieveSOAPBody) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
+    * [.retrieveSOAP(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType])](#MetadataType.retrieveSOAP) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
     * [.retrieveREST(retrieveDir, uri, [overrideType], [templateVariables])](#MetadataType.retrieveREST) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
     * [.parseResponseBody(body)](#MetadataType.parseResponseBody) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
     * [.deleteFieldByDefinition(metadataEntry, fieldPath, definitionProperty, origin)](#MetadataType.deleteFieldByDefinition) ⇒ <code>void</code>
@@ -6203,9 +6187,9 @@ Updates a single metadata entry via fuel-soap (generic lib not wrapper)
 | [overrideType] | <code>string</code> | can be used if the API type differs from the otherwise used type identifier |
 | [handleOutside] | <code>boolean</code> | if the API reponse is irregular this allows you to handle it outside of this generic method |
 
-<a name="MetadataType.retrieveSOAPgeneric"></a>
+<a name="MetadataType.retrieveSOAP"></a>
 
-### MetadataType.retrieveSOAPgeneric(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
+### MetadataType.retrieveSOAP(retrieveDir, buObject, [requestParams], [additionalFields], [overrideType]) ⇒ <code>Promise.&lt;{metadata:Util.MetadataTypeMap, type:string}&gt;</code>
 Retrieves SOAP via generic fuel-soap wrapper based metadata of metadata type into local filesystem. executes callback with retrieved metadata
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
@@ -6218,20 +6202,6 @@ Retrieves SOAP via generic fuel-soap wrapper based metadata of metadata type int
 | [requestParams] | <code>Object</code> | required for the specific request (filter for example) |
 | [additionalFields] | <code>Array.&lt;string&gt;</code> | Returns specified fields even if their retrieve definition is not set to true |
 | [overrideType] | <code>string</code> | can be used if the API type differs from the otherwise used type identifier |
-
-<a name="MetadataType.retrieveSOAPBody"></a>
-
-### MetadataType.retrieveSOAPBody(fields, [options], [type]) ⇒ <code>Promise.&lt;Util.MetadataTypeMap&gt;</code>
-helper that handles batched retrieve via SOAP
-
-**Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;Util.MetadataTypeMap&gt;</code> - keyField => metadata map  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| fields | <code>Array.&lt;string&gt;</code> | list of fields that we want to see retrieved |
-| [options] | <code>Object</code> | required for the specific request (filter for example) |
-| [type] | <code>string</code> | optionally overwrite the API type of the metadata here |
 
 <a name="MetadataType.retrieveREST"></a>
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -104,15 +104,15 @@ yargs
         desc: 'Creates Markdown or HTML documentation for the selected type',
         builder: (yargs) => {
             yargs
-                .positional('TYPE', {
-                    type: 'string',
-                    describe:
-                        'metadata type to generate docs for; currently supported: dataExtension, role',
-                })
                 .positional('BU', {
                     type: 'string',
                     describe:
                         'the business unit to generate docs for (in format "credential name/BU name")',
+                })
+                .positional('TYPE', {
+                    type: 'string',
+                    describe:
+                        'metadata type to generate docs for; currently supported: dataExtension, role',
                 });
         },
         handler: (argv) => {

--- a/lib/metadataTypes/Role.js
+++ b/lib/metadataTypes/Role.js
@@ -122,9 +122,17 @@ class Role extends MetadataType {
         this.allPermissions = {};
         // traverse all permissions recursively and write them into allPermissions object once it has reached the end
         for (const role in metadata) {
-            metadata[role].PermissionSets.PermissionSet.forEach((element) => {
-                this._traverseRoles(role, element);
-            });
+            // filter standard rules
+            if (
+                this.properties.options?.documentStandardRoles == false &&
+                metadata[role].CustomerKey.startsWith('SYS_DEF')
+            ) {
+                delete metadata[role];
+            } else {
+                metadata[role].PermissionSets.PermissionSet.forEach((element) => {
+                    this._traverseRoles(role, element);
+                });
+            }
         }
         // Create output markdown
         let output = `# Permission Overview - ${buObject.credential}\n\n`;

--- a/lib/metadataTypes/Role.js
+++ b/lib/metadataTypes/Role.js
@@ -124,7 +124,7 @@ class Role extends MetadataType {
         for (const role in metadata) {
             // filter standard rules
             if (
-                this.properties.options?.documentStandardRoles == false &&
+                this.properties.options?.documentStandardRoles === false &&
                 metadata[role].CustomerKey.startsWith('SYS_DEF')
             ) {
                 delete metadata[role];


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

_Please delete options that are not relevant._

- [ ] Documentation update
- [ ] Bug fix
- [ ] New metadata support
- [X] Enhanced metadata
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

## What changes did you make? (Give an overview)

additional flag for documentation, where one can skip documentation of Standard Roles

## Is there anything you'd like reviewers to focus on?

anything which is missing from the "base" setup

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] ESLint & Prettier are not outputting errors or warnings
- [X] README.md updated (if applicable)
- [X] CHANGELOG.md updated
- [X] ran `npm run docs` to update developer docs
