### PR TITLE
Feature/288 allow retrieving+deploying multiple types via cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,12 +627,13 @@ mcdev retrieve MyProject
 
 **retrieve specific type:**
 
-If you want to retrieve only a certain metadata type, let's say `script`, then pass this type in as a second parameter. The other types will remain untouched and in place, if you've previously retrieved them.
+If you want to retrieve only a certain metadata type, let's say `script`, then pass this type in as a second parameter. The other types will remain untouched and in place, if you've previously retrieved them.<br>Similarly, you can pass in multiple comma-separated types but make sure to put them in double-quotes in order to work on all systems.
 
 _Example:_
 
 ```bash
 mcdev retrieve MyProject/DEV script
+mcdev retrieve MyProject/DEV "script,query,automation"
 ```
 
 **retrieve all BUs:**
@@ -673,12 +674,13 @@ Similarly to `mcdev retrieve` you can also use the interactive mode to select cr
 
 **deploy sepcific type:**
 
-If you want to deploy only a certain metadata type, let's say `dataExtension`, then pass this type in as a second parameter. If there are other types in the current BU's deploy folder, these will be ignored and hence _not_ uploaded.
+If you want to deploy only a certain metadata type, let's say `dataExtension`, then pass this type in as a second parameter. If there are other types in the current BU's deploy folder, these will be ignored and hence _not_ uploaded.<br>Similarly, you can pass in multiple comma-separated types but make sure to put them in double-quotes in order to work on all systems.
 
 _Example:_
 
 ```bash
 mcdev deploy MyProject/DEV dataExtension
+mcdev deploy MyProject/DEV "script,dataExtension,importFile"
 ```
 
 **deploy all BUs:**

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -367,7 +367,6 @@ main class
     * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>void</code>
     * [.upgrade([skipInteraction])](#Mcdev.upgrade) ⇒ <code>Promise</code>
     * [.retrieve(businessUnit, [selectedType], [changelogOnly])](#Mcdev.retrieve) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [._retrieveBU(cred, bu, [selectedType], [changelogOnly])](#Mcdev._retrieveBU) ⇒ <code>Promise.&lt;object&gt;</code>
     * [._deployBU(cred, bu, [type])](#Mcdev._deployBU) ⇒ <code>Promise</code>
     * [.deploy(businessUnit, [selectedType])](#Mcdev.deploy) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.initProject([credentialsName], [skipInteraction])](#Mcdev.initProject) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -442,21 +441,6 @@ Retrieve all metadata from the specified business unit into the local file syste
 | --- | --- | --- |
 | businessUnit | <code>string</code> | references credentials from properties.json |
 | [selectedType] | <code>string</code> | limit retrieval to given metadata type |
-| [changelogOnly] | <code>boolean</code> | skip saving, only create json in memory |
-
-<a name="Mcdev._retrieveBU"></a>
-
-### Mcdev.\_retrieveBU(cred, bu, [selectedType], [changelogOnly]) ⇒ <code>Promise.&lt;object&gt;</code>
-helper for retrieve()
-
-**Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
-**Returns**: <code>Promise.&lt;object&gt;</code> - ensure that BUs are worked on sequentially  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| cred | <code>string</code> | name of Credential |
-| bu | <code>string</code> | name of BU |
-| [selectedType] | <code>string</code> | limit retrieval to given metadata type/subtype |
 | [changelogOnly] | <code>boolean</code> | skip saving, only create json in memory |
 
 <a name="Mcdev._deployBU"></a>

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -279,7 +279,7 @@ Source and target business units are also compared before the deployment to appl
 **Kind**: global class  
 
 * [Deployer](#Deployer)
-    * [new Deployer(properties, buObject, client, [type])](#new_Deployer_new)
+    * [new Deployer(properties, buObject, client, [typeArr])](#new_Deployer_new)
     * _instance_
         * [.deploy()](#Deployer+deploy) ⇒ <code>Promise</code>
         * [.deployCallback(result, metadataType)](#Deployer+deployCallback) ⇒ <code>void</code>
@@ -289,7 +289,7 @@ Source and target business units are also compared before the deployment to appl
 
 <a name="new_Deployer_new"></a>
 
-### new Deployer(properties, buObject, client, [type])
+### new Deployer(properties, buObject, client, [typeArr])
 Creates a Deployer, uses v2 auth if v2AuthOptions are passed.
 
 
@@ -305,7 +305,7 @@ Creates a Deployer, uses v2 auth if v2AuthOptions are passed.
 | buObject.mid | <code>string</code> | ID of Business Unit to authenticate with |
 | buObject.businessUnit | <code>string</code> | name of Business Unit to authenticate with |
 | client | <code>Util.SDK</code> | fuel client |
-| [type] | <code>string</code> | limit deployment to given metadata type |
+| [typeArr] | <code>string</code> | limit deployment to given metadata type |
 
 <a name="Deployer+deploy"></a>
 
@@ -337,7 +337,7 @@ Returns metadata of a business unit that is saved locally
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | deployDir | <code>string</code> |  | root directory of metadata. |
-| [type] | <code>string</code> |  | limit deployment to given metadata type |
+| [type] | <code>Array.&lt;string&gt;</code> |  | limit deployment to given metadata type |
 | [listBadKeys] | <code>boolean</code> | <code>false</code> | do not print errors, used for badKeys() |
 
 <a name="Deployer.createFolderDefinitions"></a>
@@ -367,7 +367,7 @@ main class
     * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>void</code>
     * [.upgrade([skipInteraction])](#Mcdev.upgrade) ⇒ <code>Promise</code>
     * [.retrieve(businessUnit, [selectedType], [changelogOnly])](#Mcdev.retrieve) ⇒ <code>Promise.&lt;object&gt;</code>
-    * [._deployBU(cred, bu, [type])](#Mcdev._deployBU) ⇒ <code>Promise</code>
+    * [._deployBU(cred, bu, [typeArr])](#Mcdev._deployBU) ⇒ <code>Promise</code>
     * [.deploy(businessUnit, [selectedType])](#Mcdev.deploy) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.initProject([credentialsName], [skipInteraction])](#Mcdev.initProject) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.findBUs(credentialsName)](#Mcdev.findBUs) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -445,7 +445,7 @@ Retrieve all metadata from the specified business unit into the local file syste
 
 <a name="Mcdev._deployBU"></a>
 
-### Mcdev.\_deployBU(cred, bu, [type]) ⇒ <code>Promise</code>
+### Mcdev.\_deployBU(cred, bu, [typeArr]) ⇒ <code>Promise</code>
 helper for deploy()
 
 **Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
@@ -455,7 +455,7 @@ helper for deploy()
 | --- | --- | --- |
 | cred | <code>string</code> | name of Credential |
 | bu | <code>string</code> | name of BU |
-| [type] | <code>string</code> | limit deployment to given metadata type |
+| [typeArr] | <code>Array.&lt;string&gt;</code> | limit deployment to given metadata type |
 
 <a name="Mcdev.deploy"></a>
 

--- a/lib/Deployer.js
+++ b/lib/Deployer.js
@@ -25,9 +25,9 @@ class Deployer {
      * @param {string} buObject.mid ID of Business Unit to authenticate with
      * @param {string} buObject.businessUnit name of Business Unit to authenticate with
      * @param {Util.SDK} client fuel client
-     * @param {string} [type] limit deployment to given metadata type
+     * @param {string} [typeArr] limit deployment to given metadata type
      */
-    constructor(properties, buObject, client, type) {
+    constructor(properties, buObject, client, typeArr) {
         this.buObject = buObject;
         this.client = client;
         this.properties = properties;
@@ -47,7 +47,7 @@ class Deployer {
         // Remove tmp folder of previous deploys
         File.removeSync('tmp');
         if (File.existsSync(this.deployDir)) {
-            this.metadata = Deployer.readBUMetadata(this.deployDir, type);
+            this.metadata = Deployer.readBUMetadata(this.deployDir, typeArr);
         } else {
             this.metadata = null;
             Util.logger.warn(
@@ -123,7 +123,7 @@ class Deployer {
      * Returns metadata of a business unit that is saved locally
      *
      * @param {string} deployDir root directory of metadata.
-     * @param {string} [type] limit deployment to given metadata type
+     * @param {string[]} [type] limit deployment to given metadata type
      * @param {boolean} [listBadKeys=false] do not print errors, used for badKeys()
      * @returns {object} Metadata of BU in local directory
      */
@@ -133,7 +133,7 @@ class Deployer {
             if (File.existsSync(deployDir)) {
                 const metadataTypes = File.readdirSync(deployDir);
                 metadataTypes.forEach((metadataType) => {
-                    if (MetadataTypeInfo[metadataType] && (!type || type === metadataType)) {
+                    if (MetadataTypeInfo[metadataType] && (!type || type.includes(metadataType))) {
                         // check if folder name is a valid metadataType, then check if the user limited to a certain type in the command params
                         buMetadata[metadataType] = MetadataTypeInfo[metadataType].getJsonFromFS(
                             File.normalizePath([deployDir, metadataType]),

--- a/lib/index.js
+++ b/lib/index.js
@@ -286,17 +286,23 @@ class Mcdev {
             // return null here to avoid seeing 2 error messages for the same issue
             return null;
         }
-        const [type, subType] = selectedType ? selectedType.split('-') : [];
-        if (type && !MetadataTypeInfo[type]) {
-            Util.logger.error(`:: '${type}' is not a valid metadata type`);
-            return;
-        } else if (
-            type &&
-            subType &&
-            (!MetadataTypeInfo[type] || !MetadataTypeDefinitions[type].subTypes.includes(subType))
-        ) {
-            Util.logger.error(`:: '${selectedType}' is not a valid metadata type`);
-            return;
+
+        // assume a list was passed in and check each entry's validity
+        const selectedTypesArr = selectedType ? selectedType.split(',') : [];
+        for (const selectedType of selectedTypesArr) {
+            const [type, subType] = selectedType ? selectedType.split('-') : [];
+            if (type && !MetadataTypeInfo[type]) {
+                Util.logger.error(`:: '${type}' is not a valid metadata type`);
+                return;
+            } else if (
+                type &&
+                subType &&
+                (!MetadataTypeInfo[type] ||
+                    !MetadataTypeDefinitions[type].subTypes.includes(subType))
+            ) {
+                Util.logger.error(`:: '${selectedType}' is not a valid metadata type`);
+                return;
+            }
         }
 
         if (businessUnit === '*') {
@@ -363,6 +369,7 @@ class Mcdev {
     /**
      * helper for retrieve()
      *
+     * @private
      * @param {string} cred name of Credential
      * @param {string} bu name of BU
      * @param {string} [selectedType] limit retrieval to given metadata type/subtype
@@ -382,33 +389,43 @@ class Mcdev {
             cred = buObject.credential;
             bu = buObject.businessUnit;
             Util.logger.info(`\n               :: Retrieving ${cred}/${bu}\n`);
-            let retrieveTypesArr;
-            const [type, subType] = selectedType ? selectedType.split('-') : [];
-            if (
-                type &&
-                subType &&
-                MetadataTypeInfo[type] &&
-                MetadataTypeDefinitions[type].subTypes.includes(subType)
-            ) {
-                // Clear output folder structure for selected sub-type
-                File.removeSync(
-                    File.normalizePath([properties.directories.retrieve, cred, bu, type, subType])
-                );
-                retrieveTypesArr = [selectedType];
-            } else if (type && MetadataTypeInfo[type]) {
-                // Clear output folder structure for selected type
-                File.removeSync(
-                    File.normalizePath([properties.directories.retrieve, cred, bu, type])
-                );
-                retrieveTypesArr = [type];
-            } else {
+            const retrieveTypesArr = [];
+            const selectedTypesArr = selectedType ? selectedType.split(',') : [];
+            for (const selectedType of selectedTypesArr) {
+                const [type, subType] = selectedType ? selectedType.split('-') : [];
+                if (
+                    type &&
+                    subType &&
+                    MetadataTypeInfo[type] &&
+                    MetadataTypeDefinitions[type].subTypes.includes(subType)
+                ) {
+                    // Clear output folder structure for selected sub-type
+                    File.removeSync(
+                        File.normalizePath([
+                            properties.directories.retrieve,
+                            cred,
+                            bu,
+                            type,
+                            subType,
+                        ])
+                    );
+                    retrieveTypesArr.push(selectedType);
+                } else if (type && MetadataTypeInfo[type]) {
+                    // Clear output folder structure for selected type
+                    File.removeSync(
+                        File.normalizePath([properties.directories.retrieve, cred, bu, type])
+                    );
+                    retrieveTypesArr.push(type);
+                }
+            }
+            if (!retrieveTypesArr.length) {
+                // assume no type was given and config settings are used instead:
                 // Clear output folder structure
                 File.removeSync(File.normalizePath([properties.directories.retrieve, cred, bu]));
-                // assume no type was given and config settings are used instead:
                 // removes subtypes and removes duplicates
-                retrieveTypesArr = [
-                    ...new Set(properties.metaDataTypes.retrieve.map((type) => type.split('-')[0])),
-                ];
+                retrieveTypesArr.push(
+                    ...new Set(properties.metaDataTypes.retrieve.map((type) => type.split('-')[0]))
+                );
             }
             let client;
             try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -464,10 +464,10 @@ class Mcdev {
      *
      * @param {string} cred name of Credential
      * @param {string} bu name of BU
-     * @param {string} [type] limit deployment to given metadata type
+     * @param {string[]} [typeArr] limit deployment to given metadata type
      * @returns {Promise} ensure that BUs are worked on sequentially
      */
-    static async _deployBU(cred, bu, type) {
+    static async _deployBU(cred, bu, typeArr) {
         const buPath = `${cred}/${bu}`;
         Util.logger.info(`::Deploying ${buPath}`);
         properties = properties || File.loadConfigFile();
@@ -481,7 +481,7 @@ class Mcdev {
                 Util.logger.error(ex.message);
                 return;
             }
-            const deployer = new Deployer(properties, buObject, client, type);
+            const deployer = new Deployer(properties, buObject, client, typeArr);
             try {
                 // await is required or the calls end up conflicting
                 await deployer.deploy();
@@ -502,17 +502,27 @@ class Mcdev {
         Util.logger.info('mcdev:: Deploy');
         properties = properties || File.loadConfigFile();
 
-        const [type, subType] = selectedType ? selectedType.split('-') : [];
-        if (type && !MetadataTypeInfo[type]) {
-            Util.logger.error(`:: '${type}' is not a valid metadata type`);
-            return;
-        } else if (
-            type &&
-            subType &&
-            (!MetadataTypeInfo[type] || !MetadataTypeDefinitions[type].subTypes.includes(subType))
-        ) {
-            Util.logger.error(`:: '${selectedType}' is not a valid metadata type`);
-            return;
+        // assume a list was passed in and check each entry's validity
+        // ! deploy does not support selecting subtypes yet
+        const selectedTypesArr = selectedType
+            ? selectedType.split(',').map((item) => item.split('-')[0])
+            : null;
+        if (selectedTypesArr) {
+            for (const selectedType of selectedTypesArr) {
+                const [type, subType] = selectedType ? selectedType.split('-') : [];
+                if (type && !MetadataTypeInfo[type]) {
+                    Util.logger.error(`:: '${type}' is not a valid metadata type`);
+                    return;
+                } else if (
+                    type &&
+                    subType &&
+                    (!MetadataTypeInfo[type] ||
+                        !MetadataTypeDefinitions[type].subTypes.includes(subType))
+                ) {
+                    Util.logger.error(`:: '${selectedType}' is not a valid metadata type`);
+                    return;
+                }
+            }
         }
         let counter_credBu = 0;
         if (businessUnit === '*') {
@@ -524,7 +534,7 @@ class Mcdev {
             );
             for (const buPath of deployFolders.filter((r) => r.includes(path.sep))) {
                 const [cred, bu] = buPath.split(path.sep);
-                await this._deployBU(cred, bu, type);
+                await this._deployBU(cred, bu, selectedTypesArr);
                 counter_credBu++;
                 Util.logger.info('');
                 Util.restartLogger();
@@ -564,7 +574,7 @@ class Mcdev {
                     false
                 );
                 for (const buPath of deployFolders) {
-                    await this._deployBU(cred, buPath, type);
+                    await this._deployBU(cred, buPath, selectedTypesArr);
                     counter_credBu++;
                     Util.logger.info('');
                     Util.restartLogger();
@@ -572,7 +582,7 @@ class Mcdev {
                 Util.logger.info(`\n               :: ${counter_credBu} BUs for ${cred}\n`);
             } else {
                 // either bad credential or specific BU or no BU given
-                await this._deployBU(cred, bu, type);
+                await this._deployBU(cred, bu, selectedTypesArr);
                 counter_credBu++;
             }
         }

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -679,6 +679,14 @@ function startLogger() {
             if (message) {
                 myWinston.error(message + ': ' + ex.message);
             }
+            if (ex.errorCode) {
+                // for SFMC-SDK
+                myWinston.debug(`errorCode: ${ex.errorCode}`);
+            }
+            if (ex.errorMessage) {
+                // for SFMC-SDK
+                myWinston.debug(`errorMessage: ${ex.errorMessage}`);
+            }
             let stack;
             if (
                 ['ETIMEDOUT', 'EHOSTUNREACH', 'ENOTFOUND', 'ECONNRESET', 'ECONNABORTED'].includes(
@@ -690,11 +698,7 @@ function startLogger() {
             } else {
                 stack = ex.stack;
             }
-            myWinston.debug(ex.message + ' ' + stack);
-            if (myWinston.level === 'debug') {
-                // in case we are debugging, include the clickable stack in the CLI output
-                console.log(ex.message, stack);
-            }
+            myWinston.debug(stack);
         },
         /**
          * errors should cause surrounding applications to take notice


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

_Please delete options that are not relevant._

- [ ] Documentation update
- [ ] Bug fix
- [ ] New metadata support
- [x] Enhanced metadata
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

## What changes did you make? (Give an overview)

before we could either go with the config's pre-selection of types for `retrieve` or pass in ONE type.
Now, we can pass in a list of comma-separated types instead.
Same works with `deploy`

## Is there anything you'd like reviewers to focus on?

...

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] ESLint & Prettier are not outputting errors or warnings
- [ ] README.md updated (if applicable)
- [ ] CHANGELOG.md updated
- [ ] ran `npm run docs` to update developer docs
