### PR TITLE
Feature/302 get list of extracted files for given type+key

### DIFF
--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -691,7 +691,7 @@ MessageSendActivity MetadataType
 
 * [AccountUser](#AccountUser) ⇐ [<code>MetadataType</code>](#MetadataType)
     * [.retrieve(retrieveDir, _, buObject)](#AccountUser.retrieve) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
-    * [.retrieveChangelog(buObject)](#AccountUser.retrieveChangelog) ⇒ <code>Promise.&lt;object&gt;</code>
+    * [.retrieveChangelog(buObject)](#AccountUser.retrieveChangelog) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
     * [.timeSinceDate(date)](#AccountUser.timeSinceDate) ⇒ <code>number</code>
     * [.getBuName(buObject, id)](#AccountUser.getBuName) ⇒ <code>string</code>
     * [.document(buObject, [metadata])](#AccountUser.document) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -715,11 +715,11 @@ Retrieves SOAP based metadata of metadata type into local filesystem. executes c
 
 <a name="AccountUser.retrieveChangelog"></a>
 
-### AccountUser.retrieveChangelog(buObject) ⇒ <code>Promise.&lt;object&gt;</code>
+### AccountUser.retrieveChangelog(buObject) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
 Retrieves SOAP based metadata of metadata type into local filesystem. executes callback with retrieved metadata
 
 **Kind**: static method of [<code>AccountUser</code>](#AccountUser)  
-**Returns**: <code>Promise.&lt;object&gt;</code> - Promise of metadata  
+**Returns**: <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code> - Promise of metadata  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -760,7 +760,7 @@ Creates markdown documentation of all roles
 | Param | Type | Description |
 | --- | --- | --- |
 | buObject | <code>TYPE.BuObject</code> | properties for auth |
-| [metadata] | <code>object</code> | user list |
+| [metadata] | <code>TYPE.MetadataTypeMap</code> | user list |
 
 <a name="AccountUser._generateDocMd"></a>
 
@@ -823,8 +823,8 @@ FileTransfer MetadataType
     * [.buildTemplateForNested(templateDir, targetDir, metadata, templateVariables, templateName)](#Asset.buildTemplateForNested) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._buildForNested(templateDir, targetDir, metadata, templateVariables, templateName, mode)](#Asset._buildForNested) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.parseMetadata(metadata)](#Asset.parseMetadata) ⇒ <code>TYPE.CodeExtractItem</code>
-    * [._mergeCode(metadata, deployDir, subType, [templateName])](#Asset._mergeCode) ⇒ <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code>
-    * [._mergeCode_slots(prefix, metadataSlots, readDirArr, subtypeExtension, subDirArr, fileList, customerKey, [templateName])](#Asset._mergeCode_slots) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [._mergeCode(metadata, deployDir, subType, [templateName], [fileListOnly])](#Asset._mergeCode) ⇒ <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code>
+    * [._mergeCode_slots(prefix, metadataSlots, readDirArr, subtypeExtension, subDirArr, fileList, customerKey, [templateName], [fileListOnly])](#Asset._mergeCode_slots) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._extractCode(metadata)](#Asset._extractCode) ⇒ <code>TYPE.CodeExtractItem</code>
     * [._extractCode_slots(prefix, metadataSlots, codeArr)](#Asset._extractCode_slots) ⇒ <code>void</code>
     * [.getJsonFromFS(dir)](#Asset.getJsonFromFS) ⇒ <code>object</code>
@@ -1068,37 +1068,39 @@ parses retrieved Metadata before saving
 
 <a name="Asset._mergeCode"></a>
 
-### Asset.\_mergeCode(metadata, deployDir, subType, [templateName]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code>
+### Asset.\_mergeCode(metadata, deployDir, subType, [templateName], [fileListOnly]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code>
 helper for this.preDeployTasks() that loads extracted code content back into JSON
 
 **Kind**: static method of [<code>Asset</code>](#Asset)  
 **Returns**: <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code> - fileList for templating (disregarded during deployment)  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| metadata | <code>TYPE.AssetItem</code> | a single asset definition |
-| deployDir | <code>string</code> | directory of deploy files |
-| subType | <code>TYPE.AssetSubType</code> | asset-subtype name |
-| [templateName] | <code>string</code> | name of the template used to built defintion (prior applying templating) |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| metadata | <code>TYPE.AssetItem</code> |  | a single asset definition |
+| deployDir | <code>string</code> |  | directory of deploy files |
+| subType | <code>TYPE.AssetSubType</code> |  | asset-subtype name |
+| [templateName] | <code>string</code> |  | name of the template used to built defintion (prior applying templating) |
+| [fileListOnly] | <code>boolean</code> | <code>false</code> | does not read file contents nor update metadata if true |
 
 <a name="Asset._mergeCode_slots"></a>
 
-### Asset.\_mergeCode\_slots(prefix, metadataSlots, readDirArr, subtypeExtension, subDirArr, fileList, customerKey, [templateName]) ⇒ <code>Promise.&lt;void&gt;</code>
+### Asset.\_mergeCode\_slots(prefix, metadataSlots, readDirArr, subtypeExtension, subDirArr, fileList, customerKey, [templateName], [fileListOnly]) ⇒ <code>Promise.&lt;void&gt;</code>
 helper for this.preDeployTasks() that loads extracted code content back into JSON
 
 **Kind**: static method of [<code>Asset</code>](#Asset)  
 **Returns**: <code>Promise.&lt;void&gt;</code> - -  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| prefix | <code>string</code> | usually the customerkey |
-| metadataSlots | <code>object</code> | metadata.views.html.slots or deeper slots.<>.blocks.<>.slots |
-| readDirArr | <code>Array.&lt;string&gt;</code> | directory of deploy files |
-| subtypeExtension | <code>string</code> | asset-subtype name ending on -meta |
-| subDirArr | <code>Array.&lt;string&gt;</code> | directory of files w/o leading deploy dir |
-| fileList | <code>Array.&lt;object&gt;</code> | directory of files w/o leading deploy dir |
-| customerKey | <code>string</code> | external key of template (could have been changed if used during templating) |
-| [templateName] | <code>string</code> | name of the template used to built defintion (prior applying templating) |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| prefix | <code>string</code> |  | usually the customerkey |
+| metadataSlots | <code>object</code> |  | metadata.views.html.slots or deeper slots.<>.blocks.<>.slots |
+| readDirArr | <code>Array.&lt;string&gt;</code> |  | directory of deploy files |
+| subtypeExtension | <code>string</code> |  | asset-subtype name ending on -meta |
+| subDirArr | <code>Array.&lt;string&gt;</code> |  | directory of files w/o leading deploy dir |
+| fileList | <code>Array.&lt;object&gt;</code> |  | directory of files w/o leading deploy dir |
+| customerKey | <code>string</code> |  | external key of template (could have been changed if used during templating) |
+| [templateName] | <code>string</code> |  | name of the template used to built defintion (prior applying templating) |
+| [fileListOnly] | <code>boolean</code> | <code>false</code> | does not read file contents nor update metadata if true |
 
 <a name="Asset._extractCode"></a>
 
@@ -3866,7 +3868,7 @@ Creates markdown documentation of all roles
 | Param | Type | Description |
 | --- | --- | --- |
 | buObject | <code>TYPE.BuObject</code> | properties for auth |
-| [metadata] | <code>object</code> | role definitions |
+| [metadata] | <code>TYPE.MetadataTypeMap</code> | role definitions |
 
 <a name="Role._traverseRoles"></a>
 

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -2810,8 +2810,8 @@ Provides default functionality that can be overwritten by child metadata type cl
     * [.saveResults(results, retrieveDir, [overrideType], [templateVariables])](#MetadataType.saveResults) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMap&gt;</code>
     * [.applyTemplateValues(code, templateVariables)](#MetadataType.applyTemplateValues) ⇒ <code>string</code>
     * [.applyTemplateNames(code, templateVariables)](#MetadataType.applyTemplateNames) ⇒ <code>string</code>
-    * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName)](#MetadataType.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#MetadataType.buildTemplateForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName)](#MetadataType.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
+    * [.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#MetadataType.buildTemplateForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [.findSubType(templateDir, templateName)](#MetadataType.findSubType) ⇒ <code>string</code>
     * [.readSecondaryFolder(templateDir, typeDirArr, templateName, fileName, ex)](#MetadataType.readSecondaryFolder) ⇒ <code>object</code>
     * [.buildDefinition(templateDir, targetDir, templateName, variables)](#MetadataType.buildDefinition) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
@@ -3257,12 +3257,12 @@ searches extracted file for template variable values and applies the market vari
 
 <a name="MetadataType.buildDefinitionForExtracts"></a>
 
-### MetadataType.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName) ⇒ <code>Promise.&lt;void&gt;</code>
+### MetadataType.buildDefinitionForExtracts(templateDir, targetDir, metadata, variables, templateName) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildDefinition
 handles extracted code if any are found for complex types (e.g script, asset, query)
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - Promise  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3274,12 +3274,12 @@ handles extracted code if any are found for complex types (e.g script, asset, qu
 
 <a name="MetadataType.buildTemplateForExtracts"></a>
 
-### MetadataType.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;void&gt;</code>
+### MetadataType.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildTemplate
 handles extracted code if any are found for complex types
 
 **Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - void  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3536,8 +3536,8 @@ Query MetadataType
     * [.update(query)](#Query.update) ⇒ <code>Promise</code>
     * [.preDeployTasks(metadata, deployDir)](#Query.preDeployTasks) ⇒ <code>Promise.&lt;TYPE.QueryItem&gt;</code>
     * [.applyTemplateValues(code, templateVariables)](#Query.applyTemplateValues) ⇒ <code>string</code>
-    * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Query.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Query.buildTemplateForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Query.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
+    * [.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Query.buildTemplateForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [.parseMetadata(metadata)](#Query.parseMetadata) ⇒ <code>TYPE.CodeExtractItem</code>
 
 <a name="Query.retrieve"></a>
@@ -3638,12 +3638,12 @@ searches extracted SQL file for template variables and applies the market values
 
 <a name="Query.buildDefinitionForExtracts"></a>
 
-### Query.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;void&gt;</code>
+### Query.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildDefinition
 handles extracted code if any are found for complex types
 
 **Kind**: static method of [<code>Query</code>](#Query)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - void  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3655,12 +3655,12 @@ handles extracted code if any are found for complex types
 
 <a name="Query.buildTemplateForExtracts"></a>
 
-### Query.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;void&gt;</code>
+### Query.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildTemplate
 handles extracted code if any are found for complex types
 
 **Kind**: static method of [<code>Query</code>](#Query)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - void  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3792,9 +3792,9 @@ Script MetadataType
     * [.create(script)](#Script.create) ⇒ <code>Promise</code>
     * [._mergeCode(metadata, deployDir, [templateName])](#Script._mergeCode) ⇒ <code>Promise.&lt;string&gt;</code>
     * [.preDeployTasks(metadata, dir)](#Script.preDeployTasks) ⇒ <code>TYPE.ScriptItem</code>
-    * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Script.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Script.buildTemplateForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
-    * [._buildXForExtracts(templateDir, targetDir, metadata, templateVariables, templateName, mode)](#Script._buildXForExtracts) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Script.buildDefinitionForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
+    * [.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName)](#Script.buildTemplateForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
+    * [._buildXForExtracts(templateDir, targetDir, metadata, templateVariables, templateName, mode)](#Script._buildXForExtracts) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [.parseMetadata(metadata)](#Script.parseMetadata) ⇒ <code>TYPE.CodeExtractItem</code>
 
 <a name="Script.retrieve"></a>
@@ -3896,12 +3896,12 @@ prepares a Script for deployment
 
 <a name="Script.buildDefinitionForExtracts"></a>
 
-### Script.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;void&gt;</code>
+### Script.buildDefinitionForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildDefinition
 handles extracted code if any are found for complex types
 
 **Kind**: static method of [<code>Script</code>](#Script)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - Promise  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3913,12 +3913,12 @@ handles extracted code if any are found for complex types
 
 <a name="Script.buildTemplateForExtracts"></a>
 
-### Script.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;void&gt;</code>
+### Script.buildTemplateForExtracts(templateDir, targetDir, metadata, templateVariables, templateName) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildTemplate
 handles extracted code if any are found for complex types
 
 **Kind**: static method of [<code>Script</code>](#Script)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - void  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -3930,12 +3930,12 @@ handles extracted code if any are found for complex types
 
 <a name="Script._buildXForExtracts"></a>
 
-### Script.\_buildXForExtracts(templateDir, targetDir, metadata, templateVariables, templateName, mode) ⇒ <code>Promise.&lt;void&gt;</code>
+### Script.\_buildXForExtracts(templateDir, targetDir, metadata, templateVariables, templateName, mode) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
 helper for buildTemplateForExtracts / buildDefinitionForExtracts
 handles extracted code if any are found for complex types
 
 **Kind**: static method of [<code>Script</code>](#Script)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - Promise  
+**Returns**: <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code> - list of extracted files with path-parts provided as an array  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -411,7 +411,7 @@ main class
 
 * [Mcdev](#Mcdev)
     * [.setSkipInteraction([skipInteraction])](#Mcdev.setSkipInteraction) ⇒ <code>void</code>
-    * [.createDeltaPkg(argv)](#Mcdev.createDeltaPkg) ⇒ <code>void</code>
+    * [.createDeltaPkg(argv)](#Mcdev.createDeltaPkg) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
     * [.selectTypes()](#Mcdev.selectTypes) ⇒ <code>Promise</code>
     * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>void</code>
     * [.upgrade([skipInteraction])](#Mcdev.upgrade) ⇒ <code>Promise</code>
@@ -442,10 +442,11 @@ helper method to use unattended mode when including mcdev as a package
 
 <a name="Mcdev.createDeltaPkg"></a>
 
-### Mcdev.createDeltaPkg(argv) ⇒ <code>void</code>
+### Mcdev.createDeltaPkg(argv) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
 handler for 'mcdev createDeltaPkg
 
 **Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
+**Returns**: <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code> - list of changed items  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -228,11 +228,11 @@ Builds metadata from a template using market specific customisation
     * [new Builder(properties, buObject)](#new_Builder_new)
     * _instance_
         * [.metadata](#Builder+metadata) : <code>TYPE.MultiMetadataTypeList</code>
-        * [.buildDefinition(metadataType, name, templateVariables)](#Builder+buildDefinition) ⇒ <code>Promise</code>
-        * [.buildTemplate(metadataType, keyArr, templateVariables)](#Builder+buildTemplate) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
+        * [._buildDefinition(metadataType, name, templateVariables)](#Builder+_buildDefinition) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
+        * [._buildTemplate(metadataType, keyArr, templateVariables)](#Builder+_buildTemplate) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
     * _static_
         * [.buildTemplate(businessUnit, selectedType, keyArr, market)](#Builder.buildTemplate) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
-        * [.buildDefinition(businessUnit, selectedType, name, market)](#Builder.buildDefinition) ⇒ <code>Promise.&lt;void&gt;</code>
+        * [.buildDefinition(businessUnit, selectedType, name, market)](#Builder.buildDefinition) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
         * [.buildDefinitionBulk(listName, type, name)](#Builder.buildDefinitionBulk) ⇒ <code>Promise.&lt;void&gt;</code>
 
 <a name="new_Builder_new"></a>
@@ -254,13 +254,13 @@ Creates a Builder, uses v2 auth if v2AuthOptions are passed.
 
 ### builder.metadata : <code>TYPE.MultiMetadataTypeList</code>
 **Kind**: instance property of [<code>Builder</code>](#Builder)  
-<a name="Builder+buildDefinition"></a>
+<a name="Builder+_buildDefinition"></a>
 
-### builder.buildDefinition(metadataType, name, templateVariables) ⇒ <code>Promise</code>
+### builder.\_buildDefinition(metadataType, name, templateVariables) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
 Builds a specific metadata file by name
 
 **Kind**: instance method of [<code>Builder</code>](#Builder)  
-**Returns**: <code>Promise</code> - Promise  
+**Returns**: <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code> - Promise  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -268,9 +268,9 @@ Builds a specific metadata file by name
 | name | <code>string</code> | name of metadata to build |
 | templateVariables | <code>TYPE.TemplateMap</code> | variables to be replaced in the metadata |
 
-<a name="Builder+buildTemplate"></a>
+<a name="Builder+_buildTemplate"></a>
 
-### builder.buildTemplate(metadataType, keyArr, templateVariables) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
+### builder.\_buildTemplate(metadataType, keyArr, templateVariables) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
 Build a template based on a list of metadata files in the retrieve folder.
 
 **Kind**: instance method of [<code>Builder</code>](#Builder)  
@@ -299,11 +299,11 @@ Build a template based on a list of metadata files in the retrieve folder.
 
 <a name="Builder.buildDefinition"></a>
 
-### Builder.buildDefinition(businessUnit, selectedType, name, market) ⇒ <code>Promise.&lt;void&gt;</code>
+### Builder.buildDefinition(businessUnit, selectedType, name, market) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
 Build a specific metadata file based on a template.
 
 **Kind**: static method of [<code>Builder</code>](#Builder)  
-**Returns**: <code>Promise.&lt;void&gt;</code> - -  
+**Returns**: <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code> - -  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -5020,7 +5020,7 @@ CLI helper class
     * [.fixMcdevConfig(properties)](#Init.fixMcdevConfig) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.createIdeConfigFiles(versionBeforeUpgrade)](#Init.createIdeConfigFiles) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._updateLeaf(propertiersCur, defaultPropsCur, fieldName)](#Init._updateLeaf) ⇒ <code>void</code>
-    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Array.&lt;string&gt;</code>
+    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
     * [._createIdeConfigFile(fileNameArr, relevantForcedUpdates, [boilerplateFileContent])](#Init._createIdeConfigFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.upgradeAuthFile()](#Init.upgradeAuthFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.initGitRepo([skipInteraction])](#Init.initGitRepo) ⇒ <code>Promise.&lt;{status: string, repoName: string}&gt;</code>
@@ -5074,11 +5074,11 @@ recursive helper for _fixMcdevConfig that adds missing settings
 
 <a name="Init._getForcedUpdateList"></a>
 
-### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Array.&lt;string&gt;</code>
+### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 returns list of files that need to be updated
 
 **Kind**: static method of [<code>Init</code>](#Init)  
-**Returns**: <code>Array.&lt;string&gt;</code> - relevant files with path that need to be updated  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - relevant files with path that need to be updated  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -5249,7 +5249,7 @@ CLI helper class
     * [.fixMcdevConfig(properties)](#Init.fixMcdevConfig) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.createIdeConfigFiles(versionBeforeUpgrade)](#Init.createIdeConfigFiles) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._updateLeaf(propertiersCur, defaultPropsCur, fieldName)](#Init._updateLeaf) ⇒ <code>void</code>
-    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Array.&lt;string&gt;</code>
+    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
     * [._createIdeConfigFile(fileNameArr, relevantForcedUpdates, [boilerplateFileContent])](#Init._createIdeConfigFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.upgradeAuthFile()](#Init.upgradeAuthFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.initGitRepo([skipInteraction])](#Init.initGitRepo) ⇒ <code>Promise.&lt;{status: string, repoName: string}&gt;</code>
@@ -5303,11 +5303,11 @@ recursive helper for _fixMcdevConfig that adds missing settings
 
 <a name="Init._getForcedUpdateList"></a>
 
-### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Array.&lt;string&gt;</code>
+### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 returns list of files that need to be updated
 
 **Kind**: static method of [<code>Init</code>](#Init)  
-**Returns**: <code>Array.&lt;string&gt;</code> - relevant files with path that need to be updated  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - relevant files with path that need to be updated  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -5478,7 +5478,7 @@ CLI helper class
     * [.fixMcdevConfig(properties)](#Init.fixMcdevConfig) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.createIdeConfigFiles(versionBeforeUpgrade)](#Init.createIdeConfigFiles) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._updateLeaf(propertiersCur, defaultPropsCur, fieldName)](#Init._updateLeaf) ⇒ <code>void</code>
-    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Array.&lt;string&gt;</code>
+    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
     * [._createIdeConfigFile(fileNameArr, relevantForcedUpdates, [boilerplateFileContent])](#Init._createIdeConfigFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.upgradeAuthFile()](#Init.upgradeAuthFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.initGitRepo([skipInteraction])](#Init.initGitRepo) ⇒ <code>Promise.&lt;{status: string, repoName: string}&gt;</code>
@@ -5532,11 +5532,11 @@ recursive helper for _fixMcdevConfig that adds missing settings
 
 <a name="Init._getForcedUpdateList"></a>
 
-### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Array.&lt;string&gt;</code>
+### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 returns list of files that need to be updated
 
 **Kind**: static method of [<code>Init</code>](#Init)  
-**Returns**: <code>Array.&lt;string&gt;</code> - relevant files with path that need to be updated  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - relevant files with path that need to be updated  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -5707,7 +5707,7 @@ CLI helper class
     * [.fixMcdevConfig(properties)](#Init.fixMcdevConfig) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.createIdeConfigFiles(versionBeforeUpgrade)](#Init.createIdeConfigFiles) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._updateLeaf(propertiersCur, defaultPropsCur, fieldName)](#Init._updateLeaf) ⇒ <code>void</code>
-    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Array.&lt;string&gt;</code>
+    * [._getForcedUpdateList(projectVersion)](#Init._getForcedUpdateList) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
     * [._createIdeConfigFile(fileNameArr, relevantForcedUpdates, [boilerplateFileContent])](#Init._createIdeConfigFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.upgradeAuthFile()](#Init.upgradeAuthFile) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.initGitRepo([skipInteraction])](#Init.initGitRepo) ⇒ <code>Promise.&lt;{status: string, repoName: string}&gt;</code>
@@ -5761,11 +5761,11 @@ recursive helper for _fixMcdevConfig that adds missing settings
 
 <a name="Init._getForcedUpdateList"></a>
 
-### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Array.&lt;string&gt;</code>
+### Init.\_getForcedUpdateList(projectVersion) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 returns list of files that need to be updated
 
 **Kind**: static method of [<code>Init</code>](#Init)  
-**Returns**: <code>Array.&lt;string&gt;</code> - relevant files with path that need to be updated  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - relevant files with path that need to be updated  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -156,6 +156,9 @@ Provides default functionality that can be overwritten by child metadata type cl
 ## Functions
 
 <dl>
+<dt><a href="#csvToArray">csvToArray(csv)</a> ⇒ <code>Array.&lt;string&gt;</code></dt>
+<dd><p>helper to convert CSVs into an array. if only one value was given, it&#39;s also returned as an array</p>
+</dd>
 <dt><a href="#getUserName">getUserName(userList, item, fieldname)</a> ⇒ <code>string</code></dt>
 <dd></dd>
 <dt><a href="#setupSDK">setupSDK(credentialKey, authObject)</a> ⇒ <code><a href="#SDK">SDK</a></code></dt>
@@ -454,6 +457,7 @@ main class
     * [.buildTemplate(businessUnit, selectedType, keyArr, market)](#Mcdev.buildTemplate) ⇒ <code>Promise.&lt;TYPE.MultiMetadataTypeList&gt;</code>
     * [.buildDefinition(businessUnit, selectedType, name, market)](#Mcdev.buildDefinition) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.buildDefinitionBulk(listName, type, name)](#Mcdev.buildDefinitionBulk) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.getFilesToCommit(businessUnit, selectedType, keyArr)](#Mcdev.getFilesToCommit) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 
 <a name="Mcdev.setSkipInteraction"></a>
 
@@ -665,6 +669,18 @@ Build a specific metadata file based on a template using a list of bu-market com
 | type | <code>string</code> | supported metadata type |
 | name | <code>string</code> | name of the metadata |
 
+<a name="Mcdev.getFilesToCommit"></a>
+
+### Mcdev.getFilesToCommit(businessUnit, selectedType, keyArr) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
+**Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| businessUnit | <code>string</code> | references credentials from properties.json |
+| selectedType | <code>string</code> | supported metadata type |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
+
 <a name="AccountUser"></a>
 
 ## AccountUser ⇐ [<code>MetadataType</code>](#MetadataType)
@@ -814,6 +830,7 @@ FileTransfer MetadataType
     * [.getJsonFromFS(dir)](#Asset.getJsonFromFS) ⇒ <code>object</code>
     * [.findSubType(templateDir, templateName)](#Asset.findSubType) ⇒ <code>TYPE.AssetSubType</code>
     * [.readSecondaryFolder(templateDir, typeDirArr, templateName, fileName)](#Asset.readSecondaryFolder) ⇒ <code>TYPE.AssetItem</code>
+    * [.getFilesToCommit(keyArr)](#Asset.getFilesToCommit) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="Asset.retrieve"></a>
 
@@ -1147,6 +1164,19 @@ optional method used for some types to try a different folder structure
 | templateName | <code>string</code> | name of the metadata template |
 | fileName | <code>string</code> | name of the metadata template file w/o extension |
 
+<a name="Asset.getFilesToCommit"></a>
+
+### Asset.getFilesToCommit(keyArr) ⇒ <code>Array.&lt;string&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>Asset</code>](#Asset)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
+
 <a name="AttributeGroup"></a>
 
 ## AttributeGroup ⇐ [<code>MetadataType</code>](#MetadataType)
@@ -1202,6 +1232,7 @@ Automation MetadataType
     * [._buildSchedule(scheduleObject)](#Automation._buildSchedule) ⇒ <code>TYPE.AutomationScheduleSoap</code>
     * [._calcTime(offsetServer, dateInput, [offsetInput])](#Automation._calcTime) ⇒ <code>string</code>
     * [.document(buObject, [metadata])](#Automation.document) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [.getFilesToCommit(keyArr)](#Automation.getFilesToCommit) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="Automation.retrieve"></a>
 
@@ -1384,6 +1415,19 @@ Parses metadata into a readable Markdown/HTML format then saves it
 | buObject | <code>TYPE.BuObject</code> | properties for auth |
 | [metadata] | <code>TYPE.AutomationMap</code> | a list of dataExtension definitions |
 
+<a name="Automation.getFilesToCommit"></a>
+
+### Automation.getFilesToCommit(keyArr) ⇒ <code>Array.&lt;string&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>Automation</code>](#Automation)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
+
 <a name="Campaign"></a>
 
 ## Campaign ⇐ [<code>MetadataType</code>](#MetadataType)
@@ -1494,6 +1538,7 @@ DataExtension MetadataType
     * [.postDeleteTasks(buObject, customerKey)](#DataExtension.postDeleteTasks) ⇒ <code>void</code>
     * [.retrieveForCache(buObject, [_], [isDeploy])](#DataExtension.retrieveForCache) ⇒ <code>Promise.&lt;{metadata: TYPE.DataExtensionMap, type: string}&gt;</code>
     * [.retrieveAsTemplate(templateDir, name, templateVariables)](#DataExtension.retrieveAsTemplate) ⇒ <code>Promise.&lt;{metadata: DataExtension, type: string}&gt;</code>
+    * [.getFilesToCommit(keyArr)](#DataExtension.getFilesToCommit) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="DataExtension.upsert"></a>
 
@@ -1676,6 +1721,19 @@ Retrieves dataExtension metadata in template format.
 | templateDir | <code>string</code> | Directory where retrieved metadata directory will be saved |
 | name | <code>string</code> | name of the metadata item |
 | templateVariables | <code>TYPE.TemplateMap</code> | variables to be replaced in the metadata |
+
+<a name="DataExtension.getFilesToCommit"></a>
+
+### DataExtension.getFilesToCommit(keyArr) ⇒ <code>Array.&lt;string&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>DataExtension</code>](#DataExtension)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
 
 <a name="DataExtensionField"></a>
 
@@ -2793,9 +2851,9 @@ Provides default functionality that can be overwritten by child metadata type cl
 
 * [MetadataType](#MetadataType)
     * [.client](#MetadataType.client) : <code>TYPE.SDK</code>
-    * [.properties](#MetadataType.properties) : <code>TYPE.MultiMetadataTypeMap</code>
+    * [.properties](#MetadataType.properties) : <code>object</code>
     * [.subType](#MetadataType.subType) : <code>string</code>
-    * [.buObject](#MetadataType.buObject) : <code>object</code>
+    * [.buObject](#MetadataType.buObject) : <code>TYPE.BuObject</code>
     * [.getJsonFromFS(dir, [listBadKeys])](#MetadataType.getJsonFromFS) ⇒ <code>object</code>
     * [.getFieldNamesToRetrieve([additionalFields])](#MetadataType.getFieldNamesToRetrieve) ⇒ <code>Array.&lt;string&gt;</code>
     * [.deploy(metadata, deployDir, retrieveDir, buObject)](#MetadataType.deploy) ⇒ <code>Promise.&lt;object&gt;</code>
@@ -2838,6 +2896,7 @@ Provides default functionality that can be overwritten by child metadata type cl
     * [.postDeleteTasks(buObject, customerKey)](#MetadataType.postDeleteTasks) ⇒ <code>void</code>
     * [.deleteByKeySOAP(buObject, customerKey, [handleOutside])](#MetadataType.deleteByKeySOAP) ⇒ <code>boolean</code>
     * [.readBUMetadataForType(readDir, [listBadKeys], [buMetadata])](#MetadataType.readBUMetadataForType) ⇒ <code>object</code>
+    * [.getFilesToCommit(keyArr)](#MetadataType.getFilesToCommit) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 
 <a name="MetadataType.client"></a>
 
@@ -2845,7 +2904,7 @@ Provides default functionality that can be overwritten by child metadata type cl
 **Kind**: static property of [<code>MetadataType</code>](#MetadataType)  
 <a name="MetadataType.properties"></a>
 
-### MetadataType.properties : <code>TYPE.MultiMetadataTypeMap</code>
+### MetadataType.properties : <code>object</code>
 **Kind**: static property of [<code>MetadataType</code>](#MetadataType)  
 <a name="MetadataType.subType"></a>
 
@@ -2853,7 +2912,7 @@ Provides default functionality that can be overwritten by child metadata type cl
 **Kind**: static property of [<code>MetadataType</code>](#MetadataType)  
 <a name="MetadataType.buObject"></a>
 
-### MetadataType.buObject : <code>object</code>
+### MetadataType.buObject : <code>TYPE.BuObject</code>
 **Kind**: static property of [<code>MetadataType</code>](#MetadataType)  
 <a name="MetadataType.getJsonFromFS"></a>
 
@@ -3431,6 +3490,19 @@ Returns metadata of a business unit that is saved locally
 | [listBadKeys] | <code>boolean</code> | <code>false</code> | do not print errors, used for badKeys() |
 | [buMetadata] | <code>object</code> |  | Metadata of BU in local directory |
 
+<a name="MetadataType.getFilesToCommit"></a>
+
+### MetadataType.getFilesToCommit(keyArr) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>MetadataType</code>](#MetadataType)  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
+
 <a name="MobileCode"></a>
 
 ## MobileCode ⇐ [<code>MetadataType</code>](#MetadataType)
@@ -3556,6 +3628,7 @@ Query MetadataType
     * [.buildDefinitionForNested(templateDir, targetDir, metadata, templateVariables, templateName)](#Query.buildDefinitionForNested) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [.buildTemplateForNested(templateDir, targetDir, metadata, templateVariables, templateName)](#Query.buildTemplateForNested) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [.parseMetadata(metadata)](#Query.parseMetadata) ⇒ <code>TYPE.CodeExtractItem</code>
+    * [.getFilesToCommit(keyArr)](#Query.getFilesToCommit) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="Query.retrieve"></a>
 
@@ -3703,6 +3776,19 @@ parses retrieved Metadata before saving
 | --- | --- | --- |
 | metadata | <code>TYPE.QueryItem</code> | a single query activity definition |
 
+<a name="Query.getFilesToCommit"></a>
+
+### Query.getFilesToCommit(keyArr) ⇒ <code>Array.&lt;string&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>Query</code>](#Query)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
+
 <a name="Role"></a>
 
 ## Role ⇐ [<code>MetadataType</code>](#MetadataType)
@@ -3817,6 +3903,7 @@ Script MetadataType
     * [.buildTemplateForNested(templateDir, targetDir, metadata, templateVariables, templateName)](#Script.buildTemplateForNested) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [._buildForNested(templateDir, targetDir, metadata, templateVariables, templateName, mode)](#Script._buildForNested) ⇒ <code>Promise.&lt;Array.&lt;Array.&lt;string&gt;&gt;&gt;</code>
     * [.parseMetadata(metadata)](#Script.parseMetadata) ⇒ <code>TYPE.CodeExtractItem</code>
+    * [.getFilesToCommit(keyArr)](#Script.getFilesToCommit) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="Script.retrieve"></a>
 
@@ -3982,6 +4069,19 @@ Splits the script metadata into two parts and parses in a standard manner
 | Param | Type | Description |
 | --- | --- | --- |
 | metadata | <code>TYPE.ScriptItem</code> | a single script activity definition |
+
+<a name="Script.getFilesToCommit"></a>
+
+### Script.getFilesToCommit(keyArr) ⇒ <code>Array.&lt;string&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>Script</code>](#Script)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
 
 <a name="SetDefinition"></a>
 
@@ -4578,6 +4678,7 @@ DevOps helper class
         * [~copied](#DevOps.getDeltaList..copied) : <code>TYPE.DeltaPkgItem</code>
     * [.buildDeltaDefinitions(properties, range, [skipInteraction])](#DevOps.buildDeltaDefinitions)
     * [.document(directory, jsonReport)](#DevOps.document) ⇒ <code>void</code>
+    * [.getFilesToCommit(properties, buObject, metadataType, keyArr)](#DevOps.getFilesToCommit) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 
 <a name="DevOps.getDeltaList"></a>
 
@@ -4632,6 +4733,22 @@ create markdown file for deployment listing
 | --- | --- | --- |
 | directory | <code>string</code> | - |
 | jsonReport | <code>object</code> | - |
+
+<a name="DevOps.getFilesToCommit"></a>
+
+### DevOps.getFilesToCommit(properties, buObject, metadataType, keyArr) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
+should return only the json for all but asset, query and script that are saved as multiple files
+additionally, the documentation for dataExtension and automation should be returned
+
+**Kind**: static method of [<code>DevOps</code>](#DevOps)  
+**Returns**: <code>Promise.&lt;Array.&lt;string&gt;&gt;</code> - list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| properties | <code>object</code> | central properties object |
+| buObject | <code>TYPE.BuObject</code> | references credentials |
+| metadataType | <code>string</code> | metadata type to build |
+| keyArr | <code>Array.&lt;string&gt;</code> | customerkey of the metadata |
 
 <a name="File"></a>
 
@@ -6011,6 +6128,18 @@ configures what is displayed in the console
 | [argv.silent] | <code>boolean</code> | only errors printed to CLI |
 | [argv.verbose] | <code>boolean</code> | chatty user CLI output |
 | [argv.debug] | <code>boolean</code> | enables developer output & features |
+
+<a name="csvToArray"></a>
+
+## csvToArray(csv) ⇒ <code>Array.&lt;string&gt;</code>
+helper to convert CSVs into an array. if only one value was given, it's also returned as an array
+
+**Kind**: global function  
+**Returns**: <code>Array.&lt;string&gt;</code> - values split into an array.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| csv | <code>string</code> | potentially comma-separated value |
 
 <a name="getUserName"></a>
 

--- a/lib/Builder.js
+++ b/lib/Builder.js
@@ -53,9 +53,9 @@ class Builder {
      * @param {string} metadataType metadata type to build
      * @param {string} name name of metadata to build
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
-     * @returns {Promise} Promise
+     * @returns {Promise.<TYPE.MultiMetadataTypeList>} Promise
      */
-    async buildDefinition(metadataType, name, templateVariables) {
+    async _buildDefinition(metadataType, name, templateVariables) {
         let nameArr;
         if (name.includes(',')) {
             nameArr = name.split(',').map((item) =>
@@ -120,7 +120,7 @@ class Builder {
         if (buObject !== null) {
             const builder = new Builder(properties, buObject);
             if (Util.checkMarket(market, properties)) {
-                return builder.buildTemplate(selectedType, keyArr, properties.markets[market]);
+                return builder._buildTemplate(selectedType, keyArr, properties.markets[market]);
             }
         }
     }
@@ -132,7 +132,7 @@ class Builder {
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @returns {Promise.<TYPE.MultiMetadataTypeList>} Promise
      */
-    async buildTemplate(metadataType, keyArr, templateVariables) {
+    async _buildTemplate(metadataType, keyArr, templateVariables) {
         const type = metadataType;
         try {
             /** @type {TYPE.MetadataTypeItemObj[]} */
@@ -170,7 +170,7 @@ class Builder {
      * @param {string} selectedType supported metadata type
      * @param {string} name name of the metadata
      * @param {string} market market localizations
-     * @returns {Promise.<void>} -
+     * @returns {Promise.<TYPE.MultiMetadataTypeList>} -
      */
     static async buildDefinition(businessUnit, selectedType, name, market) {
         const properties = File.loadConfigFile();
@@ -187,7 +187,7 @@ class Builder {
         if (buObject !== null) {
             const builder = new Builder(properties, buObject);
             if (Util.checkMarket(market, properties)) {
-                builder.buildDefinition(selectedType, name, properties.markets[market]);
+                return builder._buildDefinition(selectedType, name, properties.markets[market]);
             }
         }
     }

--- a/lib/Deployer.js
+++ b/lib/Deployer.js
@@ -40,15 +40,8 @@ class Deployer {
         MetadataTypeInfo.folder.properties = this.properties;
         // Remove tmp folder of previous deploys
         File.removeSync('tmp');
-        if (File.existsSync(this.deployDir)) {
-            this.metadata = Deployer.readBUMetadata(this.deployDir, typeArr);
-        } else {
-            this.metadata = null;
-            Util.logger.warn(
-                'Deployer.constructor:: Please create a directory called deploy and include your metadata in it: ./' +
-                    this.deployDir
-            );
-        }
+        File.ensureDirSync(this.deployDir);
+        this.metadata = Deployer.readBUMetadata(this.deployDir, typeArr);
     }
     /**
      * Deploy all metadata that is located in the deployDir
@@ -125,22 +118,19 @@ class Deployer {
     static readBUMetadata(deployDir, type, listBadKeys) {
         const buMetadata = {};
         try {
-            if (File.existsSync(deployDir)) {
-                const metadataTypes = File.readdirSync(deployDir);
-                metadataTypes.forEach((metadataType) => {
-                    if (MetadataTypeInfo[metadataType] && (!type || type.includes(metadataType))) {
-                        // check if folder name is a valid metadataType, then check if the user limited to a certain type in the command params
-                        buMetadata[metadataType] = MetadataTypeInfo[metadataType].getJsonFromFS(
-                            File.normalizePath([deployDir, metadataType]),
-                            listBadKeys
-                        );
-                    }
-                });
+            File.ensureDirSync(deployDir);
+            const metadataTypes = File.readdirSync(deployDir);
+            metadataTypes.forEach((metadataType) => {
+                if (MetadataTypeInfo[metadataType] && (!type || type.includes(metadataType))) {
+                    // check if folder name is a valid metadataType, then check if the user limited to a certain type in the command params
+                    buMetadata[metadataType] = MetadataTypeInfo[metadataType].getJsonFromFS(
+                        File.normalizePath([deployDir, metadataType]),
+                        listBadKeys
+                    );
+                }
+            });
 
-                return buMetadata;
-            } else {
-                throw new Error(`Directory '${deployDir}' does not exist.`);
-            }
+            return buMetadata;
         } catch (ex) {
             throw new Error(ex.message);
         }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -212,12 +212,7 @@ yargs
         handler: (argv) => {
             Mcdev.setSkipInteraction(!!argv.skipInteraction);
             Util.setLoggingLevel(argv);
-            const keyArr = argv.KEY.includes(',')
-                ? argv.KEY.split(',').map((item) =>
-                      // allow whitespace in comma-separated lists
-                      item.trim()
-                  )
-                : [argv.KEY.trim()];
+            const keyArr = csvToArray(argv.KEY);
 
             Mcdev.buildTemplate(argv.BU, argv.TYPE, keyArr, argv.MARKET);
         },
@@ -319,6 +314,34 @@ yargs
         },
     })
     .command({
+        command: 'getFilesToCommit <BU> <TYPE> <KEY>',
+        aliases: ['fc'],
+        desc: 'returns a list of relative paths to files one needs to include in a commit',
+        builder: (yargs) => {
+            yargs
+                .positional('BU', {
+                    type: 'string',
+                    describe:
+                        'the business unit to deploy to (in format "credential name/BU name")',
+                })
+                .positional('TYPE', {
+                    type: 'string',
+                    describe: 'metadata type',
+                })
+                .positional('KEY', {
+                    type: 'string',
+                    describe: 'key(s) of the metadata component(s)',
+                });
+        },
+        handler: (argv) => {
+            Mcdev.setSkipInteraction(!!argv.skipInteraction);
+            Util.setLoggingLevel(argv);
+            const keyArr = csvToArray(argv.KEY);
+
+            Mcdev.getFilesToCommit(argv.BU, argv.TYPE, keyArr);
+        },
+    })
+    .command({
         command: 'upgrade',
         aliases: ['up'],
         desc: 'Add NPM dependencies and IDE configuration files to your project',
@@ -352,3 +375,18 @@ yargs
         'Copyright 2022. Accenture. Get support at https://github.com/Accenture/sfmc-devtools/issues'
     )
     .help().argv;
+
+/**
+ * helper to convert CSVs into an array. if only one value was given, it's also returned as an array
+ *
+ * @param {string} csv potentially comma-separated value
+ * @returns {string[]} values split into an array.
+ */
+function csvToArray(csv) {
+    return csv.includes(',')
+        ? csv.split(',').map((item) =>
+              // allow whitespace in comma-separated lists
+              item.trim()
+          )
+        : [csv.trim()];
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ class Mcdev {
     into deploy directory
      * @param {string} [argv.filter] filter file paths that start with any
      * @param {object} [argv.skipInteraction] allows to skip interactive wizard
-     * @returns {void}
+     * @returns {Promise.<TYPE.DeltaPkgItem[]>} list of changed items
      */
     static async createDeltaPkg(argv) {
         properties = properties || File.loadConfigFile();

--- a/lib/index.js
+++ b/lib/index.js
@@ -618,6 +618,30 @@ class Mcdev {
         Util.logger.info('mcdev:: Build Definition from Template Bulk');
         return Builder.buildDefinitionBulk(listName, type, name);
     }
+    /**
+     *
+     * @param {string} businessUnit references credentials from properties.json
+     * @param {string} selectedType supported metadata type
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {Promise.<string[]>} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static async getFilesToCommit(businessUnit, selectedType, keyArr) {
+        Util.logger.info('mcdev:: getFilesToCommit');
+        const properties = File.loadConfigFile();
+        if (!Util._isValidType(selectedType)) {
+            return;
+        }
+        if (selectedType.includes('-')) {
+            Util.logger.error(
+                `:: '${selectedType}' is not a valid metadata type. Please don't include subtypes.`
+            );
+            return;
+        }
+        const buObject = await Cli.getCredentialObject(properties, businessUnit);
+        if (buObject !== null) {
+            return DevOps.getFilesToCommit(properties, buObject, selectedType, keyArr);
+        }
+    }
 }
 
 module.exports = Mcdev;

--- a/lib/index.js
+++ b/lib/index.js
@@ -416,7 +416,7 @@ class Mcdev {
             return;
         }
         try {
-            const parentBUOnlyTypes = ['role'];
+            const parentBUOnlyTypes = ['accountUser', 'role'];
             const buObject = await Cli.getCredentialObject(
                 properties,
                 parentBUOnlyTypes.includes(type) ? businessUnit.split('/')[0] : businessUnit,

--- a/lib/index.js
+++ b/lib/index.js
@@ -494,22 +494,14 @@ class Mcdev {
                 docPath,
                 File.filterIllegalFilenames(buObject.businessUnit) + '.badKeys.md',
             ]);
-            if (!File.existsSync(docPath)) {
-                File.mkdirpSync(docPath);
-            } else if (File.existsSync(filename)) {
+            await File.ensureDir(docPath);
+            if (await File.pathExistsSync(filename)) {
                 File.removeSync(filename);
             }
 
             const regex = RegExp('(\\w+-){4}\\w+');
-            let metadata;
-            if (File.existsSync(retrieveDir)) {
-                metadata = Deployer.readBUMetadata(retrieveDir, null, true);
-            } else {
-                Util.logger.warn(
-                    `Looks like ${retrieveDir} does not exist. If there was no metadata retrieved this is expected, in other cases re-run retrieve to attempt to fix this issue`
-                );
-                return;
-            }
+            await File.ensureDir(retrieveDir);
+            const metadata = Deployer.readBUMetadata(retrieveDir, null, true);
             let output = '# List of Metadata with Name-Key mismatches\n';
             for (const metadataType in metadata) {
                 let listEntries = '';

--- a/lib/metadataTypes/AccountUser.js
+++ b/lib/metadataTypes/AccountUser.js
@@ -298,8 +298,8 @@ class AccountUser extends MetadataType {
         try {
             const filename = buObject.credential;
             // write to disk
-            await File.writeToFile(docPath, filename + '.accountUser', 'md', output);
-            Util.logger.info(`Created ${docPath}${filename}.accountUser.md`);
+            await File.writeToFile(docPath, filename + '.accountUsers', 'md', output);
+            Util.logger.info(`Created ${File.normalizePath([docPath, filename])}.accountUsers.md`);
             if (['html', 'both'].includes(this.properties.options.documentType)) {
                 Util.logger.warn(
                     'HTML-based documentation of accountUser currently not supported.'

--- a/lib/metadataTypes/AccountUser.js
+++ b/lib/metadataTypes/AccountUser.js
@@ -30,7 +30,7 @@ class AccountUser extends MetadataType {
      * Retrieves SOAP based metadata of metadata type into local filesystem. executes callback with retrieved metadata
      *
      * @param {object} buObject properties for auth
-     * @returns {Promise.<object>} Promise of metadata
+     * @returns {Promise.<TYPE.MetadataTypeMapObj>} Promise of metadata
      */
     static async retrieveChangelog(buObject) {
         return this._retrieve(null, null, buObject);
@@ -40,9 +40,9 @@ class AccountUser extends MetadataType {
      *
      * @param {string} retrieveDir Directory where retrieved metadata directory will be saved
      * @param {string[]} _ Returns specified fields even if their retrieve definition is not set to true
-     * @param {object} buObject properties for auth
+     * @param {TYPE.BuObject} buObject properties for auth
      * @private
-     * @returns {Promise.<object>} Promise of metadata
+     * @returns {Promise.<TYPE.MetadataTypeMapObj>} Promise of metadata
      */
     static async _retrieve(retrieveDir, _, buObject) {
         Util.logger.info('- Caching dependent Metadata: AccountUserAccount');
@@ -168,7 +168,7 @@ class AccountUser extends MetadataType {
      * Creates markdown documentation of all roles
      *
      * @param {TYPE.BuObject} buObject properties for auth
-     * @param {object} [metadata] user list
+     * @param {TYPE.MetadataTypeMap} [metadata] user list
      * @returns {Promise.<void>} -
      */
     static async document(buObject, metadata) {

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -278,7 +278,7 @@ class Asset extends MetadataType {
                 }
                 Util.setLoggingLevel(obj);
             }
-        } else if (!items.length) {
+        } else if (retrieveDir && !items.length) {
             Util.logger.info(`  Downloaded asset-${subType}: ${items.length}`);
         }
         return items;

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -640,9 +640,10 @@ class Asset extends MetadataType {
      * @param {string} deployDir directory of deploy files
      * @param {TYPE.AssetSubType} subType asset-subtype name
      * @param {string} [templateName] name of the template used to built defintion (prior applying templating)
+     * @param {boolean} [fileListOnly] does not read file contents nor update metadata if true
      * @returns {Promise.<TYPE.CodeExtract[]>} fileList for templating (disregarded during deployment)
      */
-    static async _mergeCode(metadata, deployDir, subType, templateName) {
+    static async _mergeCode(metadata, deployDir, subType, templateName, fileListOnly = false) {
         const subtypeExtension = `.${this.definition.type}-${subType}-meta`;
         const fileList = [];
         let subDirArr;
@@ -666,11 +667,13 @@ class Asset extends MetadataType {
                 ) {
                     // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
                     if (metadata.views.html) {
-                        metadata.views.html.content = await File.readFile(
-                            readDirArr,
-                            'index' + subtypeExtension,
-                            'html'
-                        );
+                        if (!fileListOnly) {
+                            metadata.views.html.content = await File.readFile(
+                                readDirArr,
+                                'index' + subtypeExtension,
+                                'html'
+                            );
+                        }
 
                         if (templateName) {
                             // to use this method in templating, store a copy of the info in fileList
@@ -694,7 +697,8 @@ class Asset extends MetadataType {
                         subDirArr,
                         fileList,
                         metadata.customerKey,
-                        templateName
+                        templateName,
+                        fileListOnly
                     );
                 }
                 break;
@@ -713,12 +717,13 @@ class Asset extends MetadataType {
                     )
                 ) {
                     // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
-                    metadata.views.text.content = await File.readFile(
-                        readDirArr,
-                        (templateName ? templateName : metadata.customerKey) + subtypeExtension,
-                        'html'
-                    );
-
+                    if (!fileListOnly) {
+                        metadata.views.text.content = await File.readFile(
+                            readDirArr,
+                            (templateName ? templateName : metadata.customerKey) + subtypeExtension,
+                            'html'
+                        );
+                    }
                     if (templateName) {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
@@ -749,7 +754,8 @@ class Asset extends MetadataType {
                         subDirArr,
                         fileList,
                         metadata.customerKey,
-                        templateName
+                        templateName,
+                        fileListOnly
                     );
                 }
 
@@ -765,12 +771,13 @@ class Asset extends MetadataType {
                 ) {
                     // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
                     if (metadata.views?.html) {
-                        metadata.views.html.content = await File.readFile(
-                            readDirArr,
-                            'index' + subtypeExtension,
-                            'html'
-                        );
-
+                        if (!fileListOnly) {
+                            metadata.views.html.content = await File.readFile(
+                                readDirArr,
+                                'views.html.content' + subtypeExtension,
+                                'html'
+                            );
+                        }
                         if (templateName) {
                             // to use this method in templating, store a copy of the info in fileList
                             fileList.push({
@@ -791,12 +798,13 @@ class Asset extends MetadataType {
                     )
                 ) {
                     // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
-                    metadata.content = await File.readFile(
-                        readDirArr,
-                        'content' + subtypeExtension,
-                        'html'
-                    );
-
+                    if (!fileListOnly) {
+                        metadata.content = await File.readFile(
+                            readDirArr,
+                            'content' + subtypeExtension,
+                            'html'
+                        );
+                    }
                     if (templateName) {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
@@ -831,11 +839,13 @@ class Asset extends MetadataType {
                     )
                 ) {
                     // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
-                    metadata.content = await File.readFile(
-                        readDirArr,
-                        (templateName ? templateName : metadata.customerKey) + subtypeExtension,
-                        'html'
-                    );
+                    if (!fileListOnly) {
+                        metadata.content = await File.readFile(
+                            readDirArr,
+                            (templateName ? templateName : metadata.customerKey) + subtypeExtension,
+                            'html'
+                        );
+                    }
                     if (templateName) {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
@@ -861,6 +871,7 @@ class Asset extends MetadataType {
      * @param {object[]} fileList directory of files w/o leading deploy dir
      * @param {string} customerKey external key of template (could have been changed if used during templating)
      * @param {string} [templateName] name of the template used to built defintion (prior applying templating)
+     * @param {boolean} [fileListOnly] does not read file contents nor update metadata if true
      * @returns {Promise.<void>} -
      */
     static async _mergeCode_slots(
@@ -871,7 +882,8 @@ class Asset extends MetadataType {
         subDirArr,
         fileList,
         customerKey,
-        templateName
+        templateName,
+        fileListOnly = false
     ) {
         for (const slot in metadataSlots) {
             if (Object.prototype.hasOwnProperty.call(metadataSlots, slot)) {
@@ -892,11 +904,13 @@ class Asset extends MetadataType {
                             ) {
                                 // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
                                 // if an extracted block was found, save it back into JSON
-                                slotObj.blocks[block].content = await File.readFile(
-                                    [...readDirArr, 'blocks'],
-                                    fileName,
-                                    'html'
-                                );
+                                if (!fileListOnly) {
+                                    slotObj.blocks[block].content = await File.readFile(
+                                        [...readDirArr, 'blocks'],
+                                        fileName,
+                                        'html'
+                                    );
+                                }
                                 if (templateName) {
                                     // to use this method in templating, store a copy of the info in fileList
                                     fileList.push({

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -647,7 +647,6 @@ class Asset extends MetadataType {
         const fileList = [];
         let subDirArr;
         let readDirArr;
-
         switch (metadata.assetType.name) {
             case 'templatebasedemail': // message
             case 'htmlemail': // message
@@ -1166,6 +1165,69 @@ class Asset extends MetadataType {
         // handles subtypes that create 1 folder per asset -> currently causes the below File.ReadFile to error out
         typeDirArr.push(templateName);
         return await File.readFile([templateDir, ...typeDirArr], fileName, 'json');
+    }
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {string[]} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static async getFilesToCommit(keyArr) {
+        const basePath = File.normalizePath([
+            this.properties.directories.retrieve,
+            this.buObject.credential,
+            this.buObject.businessUnit,
+        ]);
+
+        const fileList = (
+            await Promise.all(
+                keyArr.map(async (key) => {
+                    let subType;
+                    let filePath;
+                    let fileName;
+                    for (const st of this.definition.subTypes) {
+                        fileName = `${key}.${this.definition.type}-${st}-meta.json`;
+                        if (
+                            File.existsSync(
+                                File.normalizePath([basePath, this.definition.type, st, fileName])
+                            )
+                        ) {
+                            subType = st;
+                            filePath = [basePath, this.definition.type, st];
+                            break;
+                        } else if (
+                            File.existsSync(
+                                File.normalizePath([
+                                    basePath,
+                                    this.definition.type,
+                                    st,
+                                    key,
+                                    fileName,
+                                ])
+                            )
+                        ) {
+                            subType = st;
+                            filePath = [basePath, this.definition.type, st, key];
+                            break;
+                        }
+                    }
+                    const metadata = File.readJSONFile(filePath, fileName, true, false);
+                    const fileListNested = (
+                        await this._mergeCode(metadata, basePath, subType, metadata.customerKey)
+                    ).map((item) =>
+                        File.normalizePath([
+                            basePath,
+                            ...item.subFolder,
+                            `${item.fileName}.${item.fileExt}`,
+                        ])
+                    );
+
+                    return [File.normalizePath([...filePath, fileName]), ...fileListNested];
+                })
+            )
+        ).flat();
+        return fileList;
     }
 }
 

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -1203,7 +1203,7 @@ class Asset extends MetadataType {
                     for (const st of this.definition.subTypes) {
                         fileName = `${key}.${this.definition.type}-${st}-meta.json`;
                         if (
-                            File.existsSync(
+                            await File.pathExists(
                                 File.normalizePath([basePath, this.definition.type, st, fileName])
                             )
                         ) {
@@ -1211,7 +1211,7 @@ class Asset extends MetadataType {
                             filePath = [basePath, this.definition.type, st];
                             break;
                         } else if (
-                            File.existsSync(
+                            await File.pathExists(
                                 File.normalizePath([
                                     basePath,
                                     this.definition.type,

--- a/lib/metadataTypes/Automation.js
+++ b/lib/metadataTypes/Automation.js
@@ -769,25 +769,26 @@ class Automation extends MetadataType {
             output += `* Pattern: ${json.fileTrigger.fileNamingPattern}\n`;
             output += `* Folder:  ${json.fileTrigger.folderLocationText}\n`;
         }
-
-        let tableSeparator = '';
-        const row1 = [];
-        tabled[0].forEach((column) => {
-            row1.push(
-                `| ${column.title}${column.description ? `<br>_${column.description}_` : ''} `
-            );
-            tableSeparator += '| --- ';
-        });
-        output += row1.join('') + `|\n${tableSeparator}|\n`;
-        for (let i = 1; i < tabled.length; i++) {
-            tabled[i].forEach((field) => {
-                if (field) {
-                    output += `| _${field.i}: ${field.type}_<br>${field.name} `;
-                } else {
-                    output += '| - ';
-                }
+        if (tabled && tabled.length) {
+            let tableSeparator = '';
+            const row1 = [];
+            tabled[0].forEach((column) => {
+                row1.push(
+                    `| ${column.title}${column.description ? `<br>_${column.description}_` : ''} `
+                );
+                tableSeparator += '| --- ';
             });
-            output += '|\n';
+            output += row1.join('') + `|\n${tableSeparator}|\n`;
+            for (let i = 1; i < tabled.length; i++) {
+                tabled[i].forEach((field) => {
+                    if (field) {
+                        output += `| _${field.i}: ${field.type}_<br>${field.name} `;
+                    } else {
+                        output += '| - ';
+                    }
+                });
+                output += '|\n';
+            }
         }
         return output;
     }
@@ -806,30 +807,32 @@ class Automation extends MetadataType {
         await File.ensureDir(directory);
 
         const tabled = [];
-        tabled.push(
-            json.steps.map((step, index) => ({
-                title: `Step ${index + 1}`,
-                description: step.name || '-',
-            }))
-        );
-        let maxActivities = 0;
-        for (const step of json.steps) {
-            if (step.activities.length > maxActivities) {
-                maxActivities = step.activities.length;
-            }
-        }
-        for (let activityIndex = 0; activityIndex < maxActivities; activityIndex++) {
+        if (json.steps && json.steps.length) {
             tabled.push(
-                json.steps.map((step, stepIndex) =>
-                    step.activities[activityIndex]
-                        ? {
-                              i: stepIndex + 1 + '.' + (activityIndex + 1),
-                              name: step.activities[activityIndex].name,
-                              type: step.activities[activityIndex].r__type,
-                          }
-                        : null
-                )
+                json.steps.map((step, index) => ({
+                    title: `Step ${index + 1}`,
+                    description: step.name || '-',
+                }))
             );
+            let maxActivities = 0;
+            for (const step of json.steps) {
+                if (step.activities.length > maxActivities) {
+                    maxActivities = step.activities.length;
+                }
+            }
+            for (let activityIndex = 0; activityIndex < maxActivities; activityIndex++) {
+                tabled.push(
+                    json.steps.map((step, stepIndex) =>
+                        step.activities[activityIndex]
+                            ? {
+                                  i: stepIndex + 1 + '.' + (activityIndex + 1),
+                                  name: step.activities[activityIndex].name,
+                                  type: step.activities[activityIndex].r__type,
+                              }
+                            : null
+                    )
+                );
+            }
         }
         let output;
         if (mode === 'md') {
@@ -871,9 +874,12 @@ class Automation extends MetadataType {
                 // as part of retrieve & manual execution we could face an empty folder
                 return;
             }
-            for (const customerKey in metadata) {
-                this._writeDoc(docPath + '/', customerKey, metadata[customerKey], 'md');
-            }
+            await Promise.all(
+                Object.keys(metadata).map((key) => {
+                    this._writeDoc(docPath + '/', key, metadata[key], 'md');
+                    return metadata[key];
+                })
+            );
         }
     }
     /**
@@ -899,7 +905,7 @@ class Automation extends MetadataType {
             const fileList = keyArr
                 .map((key) => [
                     File.normalizePath([path, `${key}.${this.definition.type}-meta.json`]),
-                    File.normalizePath([path, `${key}.${this.definition.type}-doc.json`]),
+                    File.normalizePath([path, `${key}.${this.definition.type}-doc.md`]),
                 ])
                 .flat();
             return fileList;

--- a/lib/metadataTypes/Automation.js
+++ b/lib/metadataTypes/Automation.js
@@ -45,30 +45,31 @@ class Automation extends MetadataType {
     static async retrieveChangelog() {
         const results = await this.client.soap.retrieveBulk('Program', ['ObjectID']);
         const details = [];
-        (
-            await Promise.all(
-                results.Results.map((a) =>
-                    this.client.soap.retrieveBulk(
-                        'Automation',
-                        [
-                            'ProgramID',
-                            'Name',
-                            'CustomerKey',
-                            'LastSaveDate',
-                            'LastSavedBy',
-                            'CreatedBy',
-                            'CreatedDate',
-                        ],
-                        {
-                            filter: {
-                                leftOperand: 'ProgramID',
-                                operator: 'equals',
-                                rightOperand: a.ObjectID,
-                            },
-                        }
-                    )
-                )
-            )
+        (results.Results
+            ? await Promise.all(
+                  results.Results.map((a) =>
+                      this.client.soap.retrieveBulk(
+                          'Automation',
+                          [
+                              'ProgramID',
+                              'Name',
+                              'CustomerKey',
+                              'LastSaveDate',
+                              'LastSavedBy',
+                              'CreatedBy',
+                              'CreatedDate',
+                          ],
+                          {
+                              filter: {
+                                  leftOperand: 'ProgramID',
+                                  operator: 'equals',
+                                  rightOperand: a.ObjectID,
+                              },
+                          }
+                      )
+                  )
+              )
+            : []
         ).forEach((item) => {
             details.push(...item.Results);
         });

--- a/lib/metadataTypes/Automation.js
+++ b/lib/metadataTypes/Automation.js
@@ -527,7 +527,7 @@ class Automation extends MetadataType {
                                 } catch (e) {
                                     // getFromCache throws error where the dependent metadata is not found
                                     Util.logger.warn(
-                                        `Missing ${activity.r__type} activity '${activity.name}'` +
+                                        `- Missing ${activity.r__type} activity '${activity.name}'` +
                                             ` in step ${step.stepNumber || step.step}.${
                                                 activity.displayOrder
                                             }` +
@@ -537,7 +537,7 @@ class Automation extends MetadataType {
                                 }
                             } else {
                                 Util.logger.warn(
-                                    `Missing ${activity.r__type} activity '${activity.name}'` +
+                                    `- Missing ${activity.r__type} activity '${activity.name}'` +
                                         ` in step ${step.stepNumber || step.step}.${
                                             activity.displayOrder
                                         }` +
@@ -547,7 +547,7 @@ class Automation extends MetadataType {
                             }
                         } catch (ex) {
                             Util.logger.warn(
-                                `Excluding automation '${metadata.name}' from retrieve (ObjectType ${activity.objectTypeId} is unknown)`
+                                `- Excluding automation '${metadata.name}' from retrieve (ObjectType ${activity.objectTypeId} is unknown)`
                             );
                             return null;
                         }

--- a/lib/metadataTypes/Automation.js
+++ b/lib/metadataTypes/Automation.js
@@ -876,6 +876,35 @@ class Automation extends MetadataType {
             }
         }
     }
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {string[]} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static getFilesToCommit(keyArr) {
+        if (!this.properties.metaDataTypes.documentOnRetrieve.includes(this.definition.type)) {
+            // document automation is not active upon retrieve, run default method instead
+            return super.getFilesToCommit(keyArr);
+        } else {
+            // document automation is active. assume we want to commit the MD file as well
+            const path = File.normalizePath([
+                this.properties.directories.retrieve,
+                this.buObject.credential,
+                this.buObject.businessUnit,
+                this.definition.type,
+            ]);
+
+            const fileList = keyArr
+                .map((key) => [
+                    File.normalizePath([path, `${key}.${this.definition.type}-meta.json`]),
+                    File.normalizePath([path, `${key}.${this.definition.type}-doc.json`]),
+                ])
+                .flat();
+            return fileList;
+        }
+    }
 }
 
 // Assign definition to static attributes

--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -955,6 +955,35 @@ class DataExtension extends MetadataType {
         }
         return metadata;
     }
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {string[]} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static getFilesToCommit(keyArr) {
+        if (!this.properties.metaDataTypes.documentOnRetrieve.includes(this.definition.type)) {
+            // document dataExtension is not active upon retrieve, run default method instead
+            return super.getFilesToCommit(keyArr);
+        } else {
+            // document dataExtension is active. assume we want to commit the MD file as well
+            const path = File.normalizePath([
+                this.properties.directories.retrieve,
+                this.buObject.credential,
+                this.buObject.businessUnit,
+                this.definition.type,
+            ]);
+
+            const fileList = keyArr
+                .map((key) => [
+                    File.normalizePath([path, `${key}.${this.definition.type}-meta.json`]),
+                    File.normalizePath([path, `${key}.${this.definition.type}-doc.json`]),
+                ])
+                .flat();
+            return fileList;
+        }
+    }
 }
 
 // Assign definition to static attributes

--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -714,39 +714,42 @@ class DataExtension extends MetadataType {
             'IsNullable',
             'DefaultValue',
         ];
-        for (const customerKey in metadata) {
-            if (metadata[customerKey]?.Fields?.length) {
-                metadata[customerKey].Fields.forEach((field) => {
-                    field.IsNullable = !Util.isTrue(field.IsRequired);
-                    columnsToIterateThrough.forEach((key) => {
-                        if (Util.isTrue(field[key])) {
-                            field[key] = '+';
-                        } else if (Util.isFalse(field[key])) {
-                            field[key] = '-';
-                        }
+        return Promise.all(
+            Object.keys(metadata).map((customerKey) => {
+                // for (const customerKey in metadata) {
+                if (metadata[customerKey]?.Fields?.length) {
+                    metadata[customerKey].Fields.forEach((field) => {
+                        field.IsNullable = !Util.isTrue(field.IsRequired);
+                        columnsToIterateThrough.forEach((key) => {
+                            if (Util.isTrue(field[key])) {
+                                field[key] = '+';
+                            } else if (Util.isFalse(field[key])) {
+                                field[key] = '-';
+                            }
+                        });
                     });
-                });
 
-                if (['html', 'both'].includes(this.properties.options.documentType)) {
-                    this._writeDoc(
-                        docPath + '/',
-                        customerKey,
-                        metadata[customerKey],
-                        'html',
-                        columnsToPrint
-                    );
+                    if (['html', 'both'].includes(this.properties.options.documentType)) {
+                        return this._writeDoc(
+                            docPath + '/',
+                            customerKey,
+                            metadata[customerKey],
+                            'html',
+                            columnsToPrint
+                        );
+                    }
+                    if (['md', 'both'].includes(this.properties.options.documentType)) {
+                        return this._writeDoc(
+                            docPath + '/',
+                            customerKey,
+                            metadata[customerKey],
+                            'md',
+                            columnsToPrint
+                        );
+                    }
                 }
-                if (['md', 'both'].includes(this.properties.options.documentType)) {
-                    this._writeDoc(
-                        docPath + '/',
-                        customerKey,
-                        metadata[customerKey],
-                        'md',
-                        columnsToPrint
-                    );
-                }
-            }
-        }
+            })
+        );
     }
 
     /**
@@ -978,7 +981,7 @@ class DataExtension extends MetadataType {
             const fileList = keyArr
                 .map((key) => [
                     File.normalizePath([path, `${key}.${this.definition.type}-meta.json`]),
-                    File.normalizePath([path, `${key}.${this.definition.type}-doc.json`]),
+                    File.normalizePath([path, `${key}.${this.definition.type}-doc.md`]),
                 ])
                 .flat();
             return fileList;

--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -682,15 +682,20 @@ class DataExtension extends MetadataType {
      * @returns {Promise.<void>} -
      */
     static async document(buObject, metadata) {
-        if (!metadata) {
-            metadata = this.readBUMetadataForType(
-                File.normalizePath([
-                    this.properties.directories.retrieve,
-                    buObject.credential,
-                    buObject.businessUnit,
-                ]),
-                true
-            ).dataExtension;
+        try {
+            if (!metadata) {
+                metadata = this.readBUMetadataForType(
+                    File.normalizePath([
+                        this.properties.directories.retrieve,
+                        buObject.credential,
+                        buObject.businessUnit,
+                    ]),
+                    true
+                ).dataExtension;
+            }
+        } catch (ex) {
+            Util.logger.error(ex.message);
+            return;
         }
         const docPath = File.normalizePath([
             this.properties.directories.retrieve,

--- a/lib/metadataTypes/Email.js
+++ b/lib/metadataTypes/Email.js
@@ -19,7 +19,7 @@ class Email extends MetadataType {
      */
     static retrieve(retrieveDir) {
         Util.logger.warn(
-            'Classic E-Mails are deprecated and will be discontinued by SFMC in the near future. Ensure that you migrate any existing E-Mails to Content Builder as soon as possible.'
+            '- Classic E-Mails are deprecated and will be discontinued by SFMC in the near future. Ensure that you migrate any existing E-Mails to Content Builder as soon as possible.'
         );
         // !dont activate `await File.initPrettier('html');` as we only want to retrieve for migration and formatting might mess with the outcome
         return super.retrieveSOAP(retrieveDir);

--- a/lib/metadataTypes/EmailSendDefinition.js
+++ b/lib/metadataTypes/EmailSendDefinition.js
@@ -202,7 +202,7 @@ class EmailSendDefinition extends MetadataType {
                 delete metadata.Email;
             } catch (ex) {
                 Util.logger.warn(
-                    `${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': Could not find email with ID ${metadata.Email.ID} in Classic nor in Content Builder.`
+                    `- ${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': Could not find email with ID ${metadata.Email.ID} in Classic nor in Content Builder.`
                 );
             }
         }
@@ -227,7 +227,7 @@ class EmailSendDefinition extends MetadataType {
                     delete sdl.CustomObjectID;
                 } catch (ex) {
                     Util.logger.warn(
-                        `${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': Could not find Target Audience (DataExtension) with ObjectID ${sdl.CustomObjectID}.`
+                        `- ${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': Could not find Target Audience (DataExtension) with ObjectID ${sdl.CustomObjectID}.`
                     );
                 }
             }
@@ -237,7 +237,7 @@ class EmailSendDefinition extends MetadataType {
                 delete sdl.List;
             } catch (ex) {
                 Util.logger.warn(
-                    `${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': ${ex.message}`
+                    `- ${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': ${ex.message}`
                 );
             }
         }

--- a/lib/metadataTypes/MetadataType.js
+++ b/lib/metadataTypes/MetadataType.js
@@ -1166,7 +1166,7 @@ class MetadataType {
      * @param {TYPE.MetadataTypeItem} metadata main JSON file that was read from file system
      * @param {TYPE.TemplateMap} variables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
-     * @returns {Promise.<void>} Promise
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static async buildDefinitionForExtracts(
         templateDir,
@@ -1187,7 +1187,7 @@ class MetadataType {
      * @param {TYPE.MetadataTypeItem} metadata main JSON file that was read from file system
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
-     * @returns {Promise.<void>} void
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static buildTemplateForExtracts(
         templateDir,

--- a/lib/metadataTypes/MetadataType.js
+++ b/lib/metadataTypes/MetadataType.js
@@ -1445,7 +1445,7 @@ class MetadataType {
         buMetadata = buMetadata || {};
         readDir = File.normalizePath([readDir, this.definition.type]);
         try {
-            if (File.existsSync(readDir)) {
+            if (File.pathExistsSync(readDir)) {
                 // check if folder name is a valid metadataType, then check if the user limited to a certain type in the command params
                 buMetadata[this.definition.type] = this.getJsonFromFS(readDir, listBadKeys);
                 return buMetadata;

--- a/lib/metadataTypes/MetadataType.js
+++ b/lib/metadataTypes/MetadataType.js
@@ -1457,6 +1457,25 @@ class MetadataType {
             throw new Error(ex.message);
         }
     }
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {Promise.<string[]>} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static getFilesToCommit(keyArr) {
+        const typeExtension = '.' + this.definition.type + '-meta.json';
+        const path = File.normalizePath([
+            this.properties.directories.retrieve,
+            this.buObject.credential,
+            this.buObject.businessUnit,
+            this.definition.type,
+        ]);
+
+        const fileList = keyArr.map((key) => File.normalizePath([path, key + typeExtension]));
+        return fileList;
+    }
 }
 
 MetadataType.definition = {
@@ -1474,7 +1493,7 @@ MetadataType.definition = {
  */
 MetadataType.client = undefined;
 /**
- * @type {TYPE.MultiMetadataTypeMap}
+ * @type {object}
  */
 MetadataType.properties = null;
 /**
@@ -1482,7 +1501,7 @@ MetadataType.properties = null;
  */
 MetadataType.subType = null;
 /**
- * @type {object}
+ * @type {TYPE.BuObject}
  */
 MetadataType.buObject = null;
 

--- a/lib/metadataTypes/Query.js
+++ b/lib/metadataTypes/Query.js
@@ -281,6 +281,29 @@ class Query extends MetadataType {
 
         return { json: metadata, codeArr: codeArr, subFolder: null };
     }
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {string[]} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static getFilesToCommit(keyArr) {
+        const path = File.normalizePath([
+            this.properties.directories.retrieve,
+            this.buObject.credential,
+            this.buObject.businessUnit,
+            this.definition.type,
+        ]);
+
+        const fileList = keyArr
+            .map((key) => [
+                File.normalizePath([path, `${key}.${this.definition.type}-meta.json`]),
+                File.normalizePath([path, `${key}.${this.definition.type}-meta.sql`]),
+            ])
+            .flat();
+        return fileList;
+    }
 }
 
 // Assign definition & cache to static attributes

--- a/lib/metadataTypes/Query.js
+++ b/lib/metadataTypes/Query.js
@@ -230,7 +230,7 @@ class Query extends MetadataType {
 
         // write to file
         const targetDirArr = Array.isArray(targetDir) ? targetDir : [targetDir];
-        const extractedPaths = [];
+        const nestedFilePaths = [];
 
         for (const targetDir of targetDirArr) {
             File.writeToFile(
@@ -239,13 +239,13 @@ class Query extends MetadataType {
                 'sql',
                 code
             );
-            extractedPaths.push([
+            nestedFilePaths.push([
                 targetDir,
                 this.definition.type,
                 metadata[this.definition.keyField] + '.' + this.definition.type + '-meta.sql',
             ]);
         }
-        return extractedPaths;
+        return nestedFilePaths;
     }
 
     /**

--- a/lib/metadataTypes/Query.js
+++ b/lib/metadataTypes/Query.js
@@ -140,7 +140,7 @@ class Query extends MetadataType {
      * @param {TYPE.QueryItem} metadata main JSON file that was read from file system
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
-     * @returns {Promise.<void>} void
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static buildDefinitionForExtracts(
         templateDir,
@@ -167,7 +167,7 @@ class Query extends MetadataType {
      * @param {TYPE.QueryItem} metadata main JSON file that was read from file system
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
-     * @returns {Promise.<void>} void
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static buildTemplateForExtracts(
         templateDir,
@@ -196,7 +196,7 @@ class Query extends MetadataType {
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
      * @param {'definition'|'template'} mode defines what we use this helper for
-     * @returns {Promise.<void>} void
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static async _buildXForExtracts(
         templateDir,
@@ -229,6 +229,7 @@ class Query extends MetadataType {
 
         // write to file
         const targetDirArr = Array.isArray(targetDir) ? targetDir : [targetDir];
+        const extractedPaths = [];
 
         for (const targetDir of targetDirArr) {
             File.writeToFile(
@@ -237,7 +238,13 @@ class Query extends MetadataType {
                 'sql',
                 code
             );
+            extractedPaths.push([
+                targetDir,
+                this.definition.type,
+                metadata[this.definition.keyField] + '.' + this.definition.type + '-meta.sql',
+            ]);
         }
+        return extractedPaths;
     }
 
     /**

--- a/lib/metadataTypes/Role.js
+++ b/lib/metadataTypes/Role.js
@@ -132,6 +132,7 @@ class Role extends MetadataType {
             // filter standard rules
             if (
                 this.properties.options?.documentStandardRoles === false &&
+                'string' === typeof metadata[role]?.CustomerKey && // key could be numeric
                 metadata[role].CustomerKey.startsWith('SYS_DEF')
             ) {
                 delete metadata[role];
@@ -197,7 +198,7 @@ class Role extends MetadataType {
             const filename = buObject.credential;
             // write to disk
             await File.writeToFile(directory, filename + '.roles', 'md', output);
-            Util.logger.info(`Created ${directory}${filename}.roles.md`);
+            Util.logger.info(`Created ${File.normalizePath([directory, filename])}.roles.md`);
             if (['html', 'both'].includes(this.properties.options.documentType)) {
                 Util.logger.warn('HTML-based documentation of roles currently not supported.');
             }

--- a/lib/metadataTypes/Role.js
+++ b/lib/metadataTypes/Role.js
@@ -98,7 +98,7 @@ class Role extends MetadataType {
      * Creates markdown documentation of all roles
      *
      * @param {TYPE.BuObject} buObject properties for auth
-     * @param {object} [metadata] role definitions
+     * @param {TYPE.MetadataTypeMap} [metadata] role definitions
      * @returns {Promise.<void>} -
      */
     static async document(buObject, metadata) {

--- a/lib/metadataTypes/Script.js
+++ b/lib/metadataTypes/Script.js
@@ -141,7 +141,7 @@ class Script extends MetadataType {
      * @param {TYPE.ScriptItem} metadata main JSON file that was read from file system
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
-     * @returns {Promise.<void>} Promise
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static buildDefinitionForExtracts(
         templateDir,
@@ -168,7 +168,7 @@ class Script extends MetadataType {
      * @param {TYPE.ScriptItem} metadata main JSON file that was read from file system
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
-     * @returns {Promise.<void>} void
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static buildTemplateForExtracts(
         templateDir,
@@ -197,7 +197,7 @@ class Script extends MetadataType {
      * @param {TYPE.TemplateMap} templateVariables variables to be replaced in the metadata
      * @param {string} templateName name of the template to be built
      * @param {'definition'|'template'} mode defines what we use this helper for
-     * @returns {Promise.<void>} Promise
+     * @returns {Promise.<string[][]>} list of extracted files with path-parts provided as an array
      */
     static async _buildXForExtracts(
         templateDir,
@@ -227,6 +227,7 @@ class Script extends MetadataType {
 
         // write to file
         const targetDirArr = Array.isArray(targetDir) ? targetDir : [targetDir];
+        const extractedPaths = [];
 
         for (const targetDir of targetDirArr) {
             File.writeToFile(
@@ -235,7 +236,13 @@ class Script extends MetadataType {
                 'ssjs',
                 code
             );
+            extractedPaths.push([
+                targetDir,
+                this.definition.type,
+                metadata[this.definition.keyField] + '.' + this.definition.type + '-meta.ssjs',
+            ]);
         }
+        return extractedPaths;
     }
 
     /**

--- a/lib/metadataTypes/Script.js
+++ b/lib/metadataTypes/Script.js
@@ -293,6 +293,29 @@ class Script extends MetadataType {
 
         return { json: metadata, codeArr: codeArr, subFolder: null };
     }
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {string[]} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    static getFilesToCommit(keyArr) {
+        const path = File.normalizePath([
+            this.properties.directories.retrieve,
+            this.buObject.credential,
+            this.buObject.businessUnit,
+            this.definition.type,
+        ]);
+
+        const fileList = keyArr
+            .map((key) => [
+                File.normalizePath([path, `${key}.${this.definition.type}-meta.json`]),
+                File.normalizePath([path, `${key}.${this.definition.type}-meta.ssjs`]),
+            ])
+            .flat();
+        return fileList;
+    }
 }
 
 // Assign definition & cache to static attributes

--- a/lib/metadataTypes/Script.js
+++ b/lib/metadataTypes/Script.js
@@ -228,7 +228,7 @@ class Script extends MetadataType {
 
         // write to file
         const targetDirArr = Array.isArray(targetDir) ? targetDir : [targetDir];
-        const extractedPaths = [];
+        const nestedFilePaths = [];
 
         for (const targetDir of targetDirArr) {
             File.writeToFile(
@@ -237,13 +237,13 @@ class Script extends MetadataType {
                 'ssjs',
                 code
             );
-            extractedPaths.push([
+            nestedFilePaths.push([
                 targetDir,
                 this.definition.type,
                 metadata[this.definition.keyField] + '.' + this.definition.type + '-meta.ssjs',
             ]);
         }
-        return extractedPaths;
+        return nestedFilePaths;
     }
 
     /**

--- a/lib/metadataTypes/TriggeredSendDefinition.js
+++ b/lib/metadataTypes/TriggeredSendDefinition.js
@@ -127,7 +127,7 @@ class TriggeredSendDefinition extends MetadataType {
             delete metadata.CategoryID;
         } catch (ex) {
             Util.logger.warn(
-                `Triggered Send '${metadata.Name}'/'${metadata.CustomerKey}': ${ex.message}`
+                `- Triggered Send '${metadata.Name}'/'${metadata.CustomerKey}': ${ex.message}`
             );
         }
         // email
@@ -156,7 +156,7 @@ class TriggeredSendDefinition extends MetadataType {
                 delete metadata.Email;
             } catch (ex) {
                 Util.logger.warn(
-                    `${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': Could not find email with ID ${metadata.Email.ID} in Classic nor in Content Builder.`
+                    `- ${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': Could not find email with ID ${metadata.Email.ID} in Classic nor in Content Builder.`
                 );
             }
         }
@@ -166,7 +166,7 @@ class TriggeredSendDefinition extends MetadataType {
             delete metadata.List;
         } catch (ex) {
             Util.logger.warn(
-                `${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': ${ex.message}`
+                `- ${this.definition.typeName} '${metadata.Name}'/'${metadata.CustomerKey}': ${ex.message}`
             );
         }
 

--- a/lib/util/devops.js
+++ b/lib/util/devops.js
@@ -136,7 +136,7 @@ const DevOps = {
 
                 // Check if file doesn't exist in reported path, that means it was a git deletion
                 // TODO: improve git action detection by switching from diffSummary to diff with --summary result parsing
-                if (!File.existsSync(file.file)) {
+                if (!File.pathExistsSync(file.file)) {
                     file.gitAction = 'delete';
                 } else if (file.moved) {
                     file.gitAction = 'move';

--- a/lib/util/devops.js
+++ b/lib/util/devops.js
@@ -449,6 +449,21 @@ const DevOps = {
             Util.logger.error(`DevOps.document():: error | ` + ex.message);
         }
     },
+    /**
+     * should return only the json for all but asset, query and script that are saved as multiple files
+     * additionally, the documentation for dataExtension and automation should be returned
+     *
+     * @param {object} properties central properties object
+     * @param {TYPE.BuObject} buObject references credentials
+     * @param {string} metadataType metadata type to build
+     * @param {string[]} keyArr customerkey of the metadata
+     * @returns {Promise.<string[]>} list of all files that need to be committed in a flat array ['path/file1.ext', 'path/file2.ext']
+     */
+    getFilesToCommit(properties, buObject, metadataType, keyArr) {
+        MetadataType[metadataType].properties = properties;
+        MetadataType[metadataType].buObject = buObject;
+        return MetadataType[metadataType].getFilesToCommit(keyArr);
+    },
 };
 
 module.exports = DevOps;

--- a/lib/util/file.js
+++ b/lib/util/file.js
@@ -446,14 +446,14 @@ const File = {
      */
     loadConfigFile(silent) {
         let properties;
-        if (fs.existsSync(Util.configFileName)) {
+        if (fs.pathExistsSync(Util.configFileName)) {
             try {
                 properties = fs.readJsonSync(Util.configFileName);
             } catch (ex) {
                 Util.logger.error(`${ex.code}: ${ex.message}`);
                 return;
             }
-            if (fs.existsSync(Util.authFileName)) {
+            if (fs.pathExistsSync(Util.authFileName)) {
                 let auth;
                 try {
                     auth = fs.readJsonSync(Util.authFileName);

--- a/lib/util/init.config.js
+++ b/lib/util/init.config.js
@@ -200,7 +200,7 @@ const Init = {
         const creationLog = [];
         await File.ensureDir('deploy/');
         await File.ensureDir('src/cloudPages');
-        const relevantForcedUpdates = this._getForcedUpdateList(versionBeforeUpgrade);
+        const relevantForcedUpdates = await this._getForcedUpdateList(versionBeforeUpgrade);
 
         // copy in .gitignore (cant be retrieved via npm install directly)
         const gitignoreFileName = path.resolve(
@@ -286,13 +286,13 @@ const Init = {
      * returns list of files that need to be updated
      *
      * @param {string} projectVersion version found in config file of the current project
-     * @returns {string[]} relevant files with path that need to be updated
+     * @returns {Promise.<string[]>} relevant files with path that need to be updated
      */
-    _getForcedUpdateList(projectVersion) {
+    async _getForcedUpdateList(projectVersion) {
         // list of files that absolutely need to get overwritten, no questions asked, when upgrading from a version lower than the given.
         let forceIdeConfigUpdate;
         const relevantForcedUpdates = [];
-        if (File.existsSync(Util.configFileName)) {
+        if (await File.pathExists(Util.configFileName)) {
             forceIdeConfigUpdate = File.readJsonSync(
                 path.resolve(__dirname, Util.boilerplateDirectory, 'forcedUpdates.json')
             );

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -587,7 +587,6 @@ function startLogger() {
          * @returns {void}
          */
         errorStack: function (ex, message) {
-            Util.signalFatalError();
             if (message) {
                 myWinston.error(message + ': ' + ex.message);
             }
@@ -603,6 +602,7 @@ function startLogger() {
                 stack = ex.stack;
             }
             myWinston.debug(stack);
+            Util.signalFatalError();
         },
         /**
          * errors should cause surrounding applications to take notice
@@ -612,8 +612,8 @@ function startLogger() {
          * @returns {void}
          */
         error: function (msg) {
-            Util.signalFatalError();
             winstonError(msg);
+            Util.signalFatalError();
         },
     };
     Util.logger = Object.assign(myWinston, winstonExtension);

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -147,7 +147,7 @@ const Util = {
      */
     getDefaultProperties() {
         const configFileName = path.resolve(__dirname, this.boilerplateDirectory, 'config.json');
-        if (!fs.existsSync(configFileName)) {
+        if (!fs.pathExistsSync(configFileName)) {
             this.logger.debug(`Default config file not found in ${configFileName}`);
             return false;
         }


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

_Please delete options that are not relevant._

- [ ] Documentation update
- [ ] Bug fix
- [ ] New metadata support
- [ ] Enhanced metadata
- [ ] Add a CLI option
- [x] Add something to the core
- [ ] Other, please explain:

## What changes did you make? (Give an overview)

- closes #302 
this is helping GUI-based CI/CD to commit the right files by providing a list of extracted code. Specifically, this targets query, script & asset that all store at least 2 files on disk: the metadata.json and the corresponding .sql, .ssjs or .HTML file

this pr aims to provide methods that take BU, type & key and then return a list of paths that identify these non-json code files.

## Is there anything you'd like reviewers to focus on?

**merge PR #301 first**

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
- [ ] README.md updated (if applicable)
