### PR TITLE
#441 npm init shows too much output during mcdev init

### DIFF
--- a/lib/util/init.npm.js
+++ b/lib/util/init.npm.js
@@ -49,7 +49,7 @@ const Init = {
             this._getDefaultPackageJson(projectPackageJson);
             await File.writeToFile('./', 'package', 'json', JSON.stringify(projectPackageJson));
             // execute "no questions asked" npm init
-            Util.execSync('npm', ['init', '--yes']);
+            Util.execSync('npm', ['init', '--yes'], true);
             try {
                 fileContent = File.readFileSync('package.json', 'utf8');
                 if (fileContent) {

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -353,15 +353,16 @@ const Util = {
      *
      * @param {string} cmd to be executed command
      * @param {string[]} [args] list of arguments
+     * @param {boolean} [hideOutput] if true, output of command will be hidden from CLI
      * @returns {undefined}
      */
-    execSync(cmd, args) {
+    execSync(cmd, args, hideOutput) {
         args = args || [];
         Util.logger.info('⚡ ' + cmd + ' ' + args.join(' '));
 
         // the following options ensure the user sees the same output and
         // interaction options as if the command was manually run
-        const options = { stdio: [0, 1, 2] };
+        const options = hideOutput ? {} : { stdio: [0, 1, 2] };
         return child_process.execSync(cmd + ' ' + args.join(' '), options);
     },
     /**


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [x] Other, please explain: UX improvement

## What changes did you make? (Give an overview)

closes #441 

