### PR TITLE
#483 auto open markdown as preview

### DIFF
--- a/boilerplate/files/.vscode/settings.json
+++ b/boilerplate/files/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "workbench.editorAssociations": {
+        "*.md": "vscode.markdown.preview.editor"
+    },
     "explorer.fileNesting.enabled": true,
     "explorer.fileNesting.expand": false,
     "explorer.fileNesting.patterns": {

--- a/boilerplate/forcedUpdates.json
+++ b/boilerplate/forcedUpdates.json
@@ -1,5 +1,9 @@
 [
     {
+        "version": "4.1.1",
+        "files": [".vscode/settings.json"]
+    },
+    {
         "version": "4.0.0",
         "files": [".vscode/settings.json", ".vscode/extensions.json", ".prettierrc"]
     },


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

enhanced IDE experience: markdown files look pretty right away without extra clicks on preview mode button
closes #483 
