### PR TITLE
#539: Util.logger.errorStack no longer always sets exitCode

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -497,6 +497,7 @@ function startLogger() {
          */
         errorStack: function (ex, message) {
             if (message) {
+                // ! this method sets exitCode=1 via myWinston.error - but only if message was given
                 myWinston.error(message + ': ' + ex.message);
             }
             let stack;
@@ -513,7 +514,6 @@ function startLogger() {
             }
             /* eslint-enable unicorn/prefer-ternary */
             myWinston.debug(stack);
-            Util.signalFatalError();
         },
         /**
          * errors should cause surrounding applications to take notice


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

fixes #539 