### PR TITLE
Bugfix/563 trim asset keys before saving to disk

### DIFF
--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -830,7 +830,6 @@ FileTransfer MetadataType
     * [.buildTemplateForNested(templateDir, targetDir, metadata, templateVariables, templateName)](#Asset.buildTemplateForNested) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._buildForNested(templateDir, targetDir, metadata, templateVariables, templateName, mode)](#Asset._buildForNested) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.setFolderPath(metadata)](#Asset.setFolderPath)
-    * [.parseMetadata(metadata)](#Asset.parseMetadata) ⇒ <code>TYPE.CodeExtractItem</code>
     * [._mergeCode(metadata, deployDir, subType, [templateName], [fileListOnly])](#Asset._mergeCode) ⇒ <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code>
     * [._mergeCode_slots(prefix, metadataSlots, readDirArr, subtypeExtension, subDirArr, fileList, customerKey, [templateName], [fileListOnly])](#Asset._mergeCode_slots) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._extractCode(metadata)](#Asset._extractCode) ⇒ <code>TYPE.CodeExtractItem</code>
@@ -1077,18 +1076,6 @@ generic script that retrieves the folder path from cache and updates the given m
 | --- | --- | --- |
 | metadata | <code>TYPE.MetadataTypeItem</code> | a single script activity definition |
 
-<a name="Asset.parseMetadata"></a>
-
-### Asset.parseMetadata(metadata) ⇒ <code>TYPE.CodeExtractItem</code>
-parses retrieved Metadata before saving
-
-**Kind**: static method of [<code>Asset</code>](#Asset)  
-**Returns**: <code>TYPE.CodeExtractItem</code> - parsed metadata definition  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| metadata | <code>TYPE.AssetItem</code> | a single asset definition |
-
 <a name="Asset._mergeCode"></a>
 
 ### Asset.\_mergeCode(metadata, deployDir, subType, [templateName], [fileListOnly]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.CodeExtract&gt;&gt;</code>
@@ -1128,7 +1115,7 @@ helper for [preDeployTasks](preDeployTasks) that loads extracted code content ba
 <a name="Asset._extractCode"></a>
 
 ### Asset.\_extractCode(metadata) ⇒ <code>TYPE.CodeExtractItem</code>
-helper for [parseMetadata](parseMetadata) that finds code content in JSON and extracts it
+helper for [postRetrieveTasks](postRetrieveTasks) that finds code content in JSON and extracts it
 to allow saving that separately and formatted
 
 **Kind**: static method of [<code>Asset</code>](#Asset)  

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -486,7 +486,11 @@ class Asset extends MetadataType {
      * @returns {TYPE.CodeExtractItem} metadata
      */
     static postRetrieveTasks(metadata) {
-        return this.parseMetadata(metadata);
+        // folder
+        this.setFolderPath(metadata);
+        // extract HTML for selected subtypes and convert payload for easier processing in MetadataType.saveResults()
+        metadata = this._extractCode(metadata);
+        return metadata;
     }
 
     /**
@@ -778,19 +782,6 @@ class Asset extends MetadataType {
         }
     }
 
-    /**
-     * parses retrieved Metadata before saving
-     *
-     * @param {TYPE.AssetItem} metadata a single asset definition
-     * @returns {TYPE.CodeExtractItem} parsed metadata definition
-     */
-    static parseMetadata(metadata) {
-        // folder
-        this.setFolderPath(metadata);
-        // extract HTML for selected subtypes and convert payload for easier processing in MetadataType.saveResults()
-        metadata = this._extractCode(metadata);
-        return metadata;
-    }
     /**
      * helper for {@link preDeployTasks} that loads extracted code content back into JSON
      *
@@ -1104,7 +1095,7 @@ class Asset extends MetadataType {
         }
     }
     /**
-     * helper for {@link parseMetadata} that finds code content in JSON and extracts it
+     * helper for {@link postRetrieveTasks} that finds code content in JSON and extracts it
      * to allow saving that separately and formatted
      *
      * @param {TYPE.AssetItem} metadata a single asset definition

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -270,6 +270,15 @@ class Asset extends MetadataType {
 
         // only when we save results do we need the complete metadata or files. caching can skip these
         if (retrieveDir && items.length > 0) {
+            for (const item of items) {
+                if (item.customerKey.trim() !== item.customerKey) {
+                    Util.logger.warn(
+                        `  - ${this.definition.type} ${item[this.definition.nameField]} (${
+                            item[this.definition.keyField]
+                        }) has leading or trailing spaces in customerKey. Please remove them in SFMC.`
+                    );
+                }
+            }
             // we have to wait on execution or it potentially causes memory reference issues when changing between BUs
             await this.requestAndSaveExtended(items, subType, retrieveDir, templateVariables);
             Util.logger.debug(`Downloaded asset-${subType}: ${items.length}`);
@@ -797,13 +806,15 @@ class Asset extends MetadataType {
         const fileList = [];
         let subDirArr;
         let readDirArr;
+        // unfortunately, asset's key can contain spaces at beginning/end which can break the file system when folders are created with it
+        const customerKey = metadata.customerKey.trim();
         switch (metadata.assetType.name) {
             case 'templatebasedemail': // message
             case 'htmlemail': {
                 // message
                 // this complex type always creates its own subdir per asset
                 subDirArr = [this.definition.type, subType];
-                readDirArr = [deployDir, ...subDirArr, templateName || metadata.customerKey];
+                readDirArr = [deployDir, ...subDirArr, templateName || customerKey];
 
                 // metadata.views.html.content (mandatory)
                 // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
@@ -824,7 +835,7 @@ class Asset extends MetadataType {
                     if (templateName) {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
-                            subFolder: [...subDirArr, metadata.customerKey],
+                            subFolder: [...subDirArr, customerKey],
                             fileName: 'index' + subtypeExtension,
                             fileExt: 'html',
                             content: metadata.views.html.content,
@@ -841,7 +852,7 @@ class Asset extends MetadataType {
                         subtypeExtension,
                         subDirArr,
                         fileList,
-                        metadata.customerKey,
+                        customerKey,
                         templateName,
                         fileListOnly
                     );
@@ -857,9 +868,7 @@ class Asset extends MetadataType {
                     await File.pathExists(
                         File.normalizePath([
                             ...readDirArr,
-                            `${
-                                templateName || metadata.customerKey // TODO check why this could be templateName
-                            }${subtypeExtension}.html`,
+                            `${templateName || customerKey}${subtypeExtension}.html`,
                         ])
                     )
                 ) {
@@ -867,7 +876,7 @@ class Asset extends MetadataType {
                     if (!fileListOnly) {
                         metadata.views.text.content = await File.readFilteredFilename(
                             readDirArr,
-                            (templateName || metadata.customerKey) + subtypeExtension,
+                            (templateName || customerKey) + subtypeExtension,
                             'html'
                         );
                     }
@@ -875,7 +884,7 @@ class Asset extends MetadataType {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
                             subFolder: subDirArr,
-                            fileName: metadata.customerKey + subtypeExtension,
+                            fileName: customerKey + subtypeExtension,
                             fileExt: 'html',
                             content: metadata.views.text.content,
                         });
@@ -887,7 +896,7 @@ class Asset extends MetadataType {
                 // asset
                 // this complex type always creates its own subdir per asset
                 subDirArr = [this.definition.type, subType];
-                readDirArr = [deployDir, ...subDirArr, templateName || metadata.customerKey];
+                readDirArr = [deployDir, ...subDirArr, templateName || customerKey];
 
                 // metadata.views.html.slots.<>.blocks.<>.content (optional) (pre & post 20222)
                 if (metadata?.views?.html?.slots) {
@@ -898,7 +907,7 @@ class Asset extends MetadataType {
                         subtypeExtension,
                         subDirArr,
                         fileList,
-                        metadata.customerKey,
+                        customerKey,
                         templateName,
                         fileListOnly
                     );
@@ -925,7 +934,7 @@ class Asset extends MetadataType {
                     if (templateName) {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
-                            subFolder: [...subDirArr, metadata.customerKey],
+                            subFolder: [...subDirArr, customerKey],
                             fileName: 'views.html.content' + subtypeExtension,
                             fileExt: 'html',
                             content: metadata.views.html.content,
@@ -951,7 +960,7 @@ class Asset extends MetadataType {
                     if (templateName) {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
-                            subFolder: [...subDirArr, metadata.customerKey],
+                            subFolder: [...subDirArr, customerKey],
                             fileName: 'content' + subtypeExtension,
                             fileExt: 'html',
                             content: metadata.views.html.content,
@@ -984,7 +993,7 @@ class Asset extends MetadataType {
                         await File.pathExists(
                             File.normalizePath([
                                 ...readDirArr,
-                                `${templateName || metadata.customerKey}${subtypeExtension}.${ext}`,
+                                `${templateName || customerKey}${subtypeExtension}.${ext}`,
                             ])
                         )
                     ) {
@@ -992,7 +1001,7 @@ class Asset extends MetadataType {
                         if (!fileListOnly) {
                             metadata.content = await File.readFilteredFilename(
                                 readDirArr,
-                                (templateName || metadata.customerKey) + subtypeExtension,
+                                (templateName || customerKey) + subtypeExtension,
                                 ext
                             );
                         }
@@ -1000,7 +1009,7 @@ class Asset extends MetadataType {
                             // to use this method in templating, store a copy of the info in fileList
                             fileList.push({
                                 subFolder: subDirArr,
-                                fileName: (templateName || metadata.customerKey) + subtypeExtension,
+                                fileName: (templateName || customerKey) + subtypeExtension,
                                 fileExt: ext,
                                 content: metadata.content,
                             });
@@ -1104,6 +1113,8 @@ class Asset extends MetadataType {
     static _extractCode(metadata) {
         const codeArr = [];
         let subType;
+        // unfortunately, asset's key can contain spaces at beginning/end which can break the file system when folders are created with it
+        const customerKey = metadata.customerKey.trim();
         switch (metadata.assetType.name) {
             case 'templatebasedemail': // message
             case 'htmlemail': {
@@ -1124,7 +1135,11 @@ class Asset extends MetadataType {
                     this._extractCode_slots('views.html.slots', metadata.views.html.slots, codeArr);
                 }
 
-                return { json: metadata, codeArr: codeArr, subFolder: [metadata.customerKey] };
+                return {
+                    json: metadata,
+                    codeArr: codeArr,
+                    subFolder: [customerKey],
+                };
             }
             case 'textonlyemail': {
                 // message
@@ -1132,7 +1147,7 @@ class Asset extends MetadataType {
                 if (metadata.views?.text?.content?.length) {
                     codeArr.push({
                         subFolder: null,
-                        fileName: metadata.customerKey,
+                        fileName: customerKey,
                         fileExt: 'html',
                         content: metadata.views.text.content,
                     });
@@ -1170,7 +1185,11 @@ class Asset extends MetadataType {
                     });
                     delete metadata.content;
                 }
-                return { json: metadata, codeArr: codeArr, subFolder: [metadata.customerKey] };
+                return {
+                    json: metadata,
+                    codeArr: codeArr,
+                    subFolder: [customerKey],
+                };
             }
             case 'buttonblock': // block - Button Block
             case 'freeformblock': // block
@@ -1193,7 +1212,7 @@ class Asset extends MetadataType {
                 if (metadata?.content?.length) {
                     codeArr.push({
                         subFolder: null,
-                        fileName: metadata.customerKey,
+                        fileName: customerKey,
                         fileExt: fileExt,
                         content: metadata.content,
                     });


### PR DESCRIPTION
# PR details

fixes #563 

now shows a warning during retrieve:
![image](https://user-images.githubusercontent.com/1917227/203829570-623ee071-0fac-44e2-bdd9-09a3ff09c585.png)

and makes sure that folder names are saved without spaces (main folder did include a space at the end before):
![image](https://user-images.githubusercontent.com/1917227/203829736-aabc6b9b-ae59-4c64-80a7-2b99977f1bfd.png)

the before status actually prevented `git add` and similar applications to process files inside of that folder, at least on Windows.
The json-file's name itself is untouched by the change to avoid issues with generic scripts