### PR TITLE
Revert "Bump simple-git from 3.14.1 to 3.15.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "prettier-plugin-sql": "0.12.1",
                 "semver": "7.3.8",
                 "sfmc-sdk": "0.6.1",
-                "simple-git": "3.15.0",
+                "simple-git": "3.14.1",
                 "toposort": "2.0.2",
                 "update-notifier": "5.1.0",
                 "winston": "3.8.2",
@@ -7616,9 +7616,9 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/simple-git": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-            "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz",
+            "integrity": "sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==",
             "dependencies": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",
@@ -14353,9 +14353,9 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "simple-git": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.0.tgz",
-            "integrity": "sha512-FiWoMPlcYHQ+ApRihUsGjC/ZmIlWj62S6MBCwOunczvXcLQt+9ZdrysDrR6QVepkRQfEAaBXrN2QtJKrN6zbtg==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.14.1.tgz",
+            "integrity": "sha512-1ThF4PamK9wBORVGMK9HK5si4zoGS2GpRO7tkAFObA4FZv6dKaCVHLQT+8zlgiBm6K2h+wEU9yOaFCu/SR3OyA==",
             "requires": {
                 "@kwsites/file-exists": "^1.1.1",
                 "@kwsites/promise-deferred": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "prettier-plugin-sql": "0.12.1",
         "semver": "7.3.8",
         "sfmc-sdk": "0.6.1",
-        "simple-git": "3.15.0",
+        "simple-git": "3.14.1",
         "toposort": "2.0.2",
         "update-notifier": "5.1.0",
         "winston": "3.8.2",


### PR DESCRIPTION
Reverts Accenture/sfmc-devtools#588

already fixed on develop branch