### PR TITLE
Feature/554 auto generate markets and marketlist upon mcdev init + fixes #590 bug around git user names/emails

### DIFF
--- a/boilerplate/config.json
+++ b/boilerplate/config.json
@@ -62,14 +62,10 @@
     },
     "marketList": {
         "deployment-source": {
-            "description": "Define one 1:1 BU-Market combo here to as source for automated creation of deployment packages; you can create more than one source market list",
-            "MySandbox/DEV-NL": "DEV-NL"
+            "description": "Define one 1:1 BU-Market combo here to as source for automated creation of deployment packages; you can create more than one source market list"
         },
         "deployment-target": {
-            "description": "Define n BU-Market combo here to as target for automated creation of deployment packages; you can create more than one target market list and they can be as complex as you like",
-            "MySandbox/QA-DE": "QA-DE",
-            "MyProduction/PROD-DE": "PROD-DE",
-            "MyProduction/PROD-NL": "PROD-NL"
+            "description": "Define n BU-Market combo here to as target for automated creation of deployment packages; you can create more than one target market list and they can be as complex as you like"
         }
     },
     "metaDataTypes": {

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -176,8 +176,6 @@ Provides default functionality that can be overwritten by child metadata type cl
 <dt><a href="#csvToArray">csvToArray(csv)</a> ⇒ <code>Array.&lt;string&gt;</code></dt>
 <dd><p>helper to convert CSVs into an array. if only one value was given, it&#39;s also returned as an array</p>
 </dd>
-<dt><a href="#systemSync">systemSync(cmd)</a></dt>
-<dd></dd>
 <dt><a href="#getUserName">getUserName(userList, item, fieldname)</a> ⇒ <code>string</code></dt>
 <dd></dd>
 <dt><a href="#setupSDK">setupSDK(sessionKey, authObject)</a> ⇒ <code><a href="#SDK">SDK</a></code></dt>
@@ -6821,15 +6819,6 @@ helper to convert CSVs into an array. if only one value was given, it's also ret
 | Param | Type | Description |
 | --- | --- | --- |
 | csv | <code>string</code> | potentially comma-separated value or null |
-
-<a name="systemSync"></a>
-
-## systemSync(cmd)
-**Kind**: global function  
-
-| Param |
-| --- |
-| cmd | 
 
 <a name="getUserName"></a>
 

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -176,6 +176,8 @@ Provides default functionality that can be overwritten by child metadata type cl
 <dt><a href="#csvToArray">csvToArray(csv)</a> ⇒ <code>Array.&lt;string&gt;</code></dt>
 <dd><p>helper to convert CSVs into an array. if only one value was given, it&#39;s also returned as an array</p>
 </dd>
+<dt><a href="#systemSync">systemSync(cmd)</a></dt>
+<dd></dd>
 <dt><a href="#getUserName">getUserName(userList, item, fieldname)</a> ⇒ <code>string</code></dt>
 <dd></dd>
 <dt><a href="#setupSDK">setupSDK(sessionKey, authObject)</a> ⇒ <code><a href="#SDK">SDK</a></code></dt>
@@ -4867,7 +4869,7 @@ CLI entry for SFMC DevTools
     * [.inverseGet(objs, val)](#Util.inverseGet) ⇒ <code>string</code>
     * [.getMetadataHierachy(metadataTypes)](#Util.getMetadataHierachy) ⇒ <code>Array.&lt;string&gt;</code>
     * [.resolveObjPath(path, obj)](#Util.resolveObjPath) ⇒ <code>any</code>
-    * [.execSync(cmd, [args], [hideOutput])](#Util.execSync) ⇒ <code>undefined</code>
+    * [.execSync(cmd, [args], [hideOutput])](#Util.execSync) ⇒ <code>string</code>
     * [.templateSearchResult(results, keyToSearch, searchValue)](#Util.templateSearchResult) ⇒ <code>TYPE.MetadataTypeItem</code>
     * [.setLoggingLevel(argv)](#Util.setLoggingLevel) ⇒ <code>void</code>
 
@@ -5064,10 +5066,11 @@ let's you dynamically walk down an object and get a value
 
 <a name="Util.execSync"></a>
 
-### Util.execSync(cmd, [args], [hideOutput]) ⇒ <code>undefined</code>
+### Util.execSync(cmd, [args], [hideOutput]) ⇒ <code>string</code>
 helper to run other commands as if run manually by user
 
 **Kind**: static method of [<code>Util</code>](#Util)  
+**Returns**: <code>string</code> - output of command if hideOutput is true  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -5709,6 +5712,7 @@ CLI helper class
     * [._updateGitConfigUser()](#Init._updateGitConfigUser) ⇒ <code>void</code>
     * [._getGitConfigUser()](#Init._getGitConfigUser) ⇒ <code>Promise.&lt;{&#x27;user.name&#x27;: string, &#x27;user.email&#x27;: string}&gt;</code>
     * [.initProject(properties, credentialName)](#Init.initProject) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [._initMarkets()](#Init._initMarkets)
     * [._downloadAllBUs(bu, gitStatus)](#Init._downloadAllBUs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.upgradeProject(properties, [initial], [repoName])](#Init.upgradeProject) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._getMissingCredentials(properties)](#Init._getMissingCredentials) ⇒ <code>Array.&lt;string&gt;</code>
@@ -5831,6 +5835,12 @@ Creates template file for properties.json
 | properties | <code>TYPE.Mcdevrc</code> | config file's json |
 | credentialName | <code>string</code> | identifying name of the installed package / project |
 
+<a name="Init._initMarkets"></a>
+
+### Init.\_initMarkets()
+helper for @initProject that optionally creates markets and market lists for all BUs
+
+**Kind**: static method of [<code>Init</code>](#Init)  
 <a name="Init._downloadAllBUs"></a>
 
 ### Init.\_downloadAllBUs(bu, gitStatus) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -5916,6 +5926,7 @@ CLI helper class
     * [._updateGitConfigUser()](#Init._updateGitConfigUser) ⇒ <code>void</code>
     * [._getGitConfigUser()](#Init._getGitConfigUser) ⇒ <code>Promise.&lt;{&#x27;user.name&#x27;: string, &#x27;user.email&#x27;: string}&gt;</code>
     * [.initProject(properties, credentialName)](#Init.initProject) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [._initMarkets()](#Init._initMarkets)
     * [._downloadAllBUs(bu, gitStatus)](#Init._downloadAllBUs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.upgradeProject(properties, [initial], [repoName])](#Init.upgradeProject) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._getMissingCredentials(properties)](#Init._getMissingCredentials) ⇒ <code>Array.&lt;string&gt;</code>
@@ -6038,6 +6049,12 @@ Creates template file for properties.json
 | properties | <code>TYPE.Mcdevrc</code> | config file's json |
 | credentialName | <code>string</code> | identifying name of the installed package / project |
 
+<a name="Init._initMarkets"></a>
+
+### Init.\_initMarkets()
+helper for @initProject that optionally creates markets and market lists for all BUs
+
+**Kind**: static method of [<code>Init</code>](#Init)  
 <a name="Init._downloadAllBUs"></a>
 
 ### Init.\_downloadAllBUs(bu, gitStatus) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -6123,6 +6140,7 @@ CLI helper class
     * [._updateGitConfigUser()](#Init._updateGitConfigUser) ⇒ <code>void</code>
     * [._getGitConfigUser()](#Init._getGitConfigUser) ⇒ <code>Promise.&lt;{&#x27;user.name&#x27;: string, &#x27;user.email&#x27;: string}&gt;</code>
     * [.initProject(properties, credentialName)](#Init.initProject) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [._initMarkets()](#Init._initMarkets)
     * [._downloadAllBUs(bu, gitStatus)](#Init._downloadAllBUs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.upgradeProject(properties, [initial], [repoName])](#Init.upgradeProject) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._getMissingCredentials(properties)](#Init._getMissingCredentials) ⇒ <code>Array.&lt;string&gt;</code>
@@ -6245,6 +6263,12 @@ Creates template file for properties.json
 | properties | <code>TYPE.Mcdevrc</code> | config file's json |
 | credentialName | <code>string</code> | identifying name of the installed package / project |
 
+<a name="Init._initMarkets"></a>
+
+### Init.\_initMarkets()
+helper for @initProject that optionally creates markets and market lists for all BUs
+
+**Kind**: static method of [<code>Init</code>](#Init)  
 <a name="Init._downloadAllBUs"></a>
 
 ### Init.\_downloadAllBUs(bu, gitStatus) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -6330,6 +6354,7 @@ CLI helper class
     * [._updateGitConfigUser()](#Init._updateGitConfigUser) ⇒ <code>void</code>
     * [._getGitConfigUser()](#Init._getGitConfigUser) ⇒ <code>Promise.&lt;{&#x27;user.name&#x27;: string, &#x27;user.email&#x27;: string}&gt;</code>
     * [.initProject(properties, credentialName)](#Init.initProject) ⇒ <code>Promise.&lt;void&gt;</code>
+    * [._initMarkets()](#Init._initMarkets)
     * [._downloadAllBUs(bu, gitStatus)](#Init._downloadAllBUs) ⇒ <code>Promise.&lt;void&gt;</code>
     * [.upgradeProject(properties, [initial], [repoName])](#Init.upgradeProject) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [._getMissingCredentials(properties)](#Init._getMissingCredentials) ⇒ <code>Array.&lt;string&gt;</code>
@@ -6452,6 +6477,12 @@ Creates template file for properties.json
 | properties | <code>TYPE.Mcdevrc</code> | config file's json |
 | credentialName | <code>string</code> | identifying name of the installed package / project |
 
+<a name="Init._initMarkets"></a>
+
+### Init.\_initMarkets()
+helper for @initProject that optionally creates markets and market lists for all BUs
+
+**Kind**: static method of [<code>Init</code>](#Init)  
 <a name="Init._downloadAllBUs"></a>
 
 ### Init.\_downloadAllBUs(bu, gitStatus) ⇒ <code>Promise.&lt;void&gt;</code>
@@ -6542,7 +6573,7 @@ Util that contains logger and simple util methods
     * [.inverseGet(objs, val)](#Util.inverseGet) ⇒ <code>string</code>
     * [.getMetadataHierachy(metadataTypes)](#Util.getMetadataHierachy) ⇒ <code>Array.&lt;string&gt;</code>
     * [.resolveObjPath(path, obj)](#Util.resolveObjPath) ⇒ <code>any</code>
-    * [.execSync(cmd, [args], [hideOutput])](#Util.execSync) ⇒ <code>undefined</code>
+    * [.execSync(cmd, [args], [hideOutput])](#Util.execSync) ⇒ <code>string</code>
     * [.templateSearchResult(results, keyToSearch, searchValue)](#Util.templateSearchResult) ⇒ <code>TYPE.MetadataTypeItem</code>
     * [.setLoggingLevel(argv)](#Util.setLoggingLevel) ⇒ <code>void</code>
 
@@ -6739,10 +6770,11 @@ let's you dynamically walk down an object and get a value
 
 <a name="Util.execSync"></a>
 
-### Util.execSync(cmd, [args], [hideOutput]) ⇒ <code>undefined</code>
+### Util.execSync(cmd, [args], [hideOutput]) ⇒ <code>string</code>
 helper to run other commands as if run manually by user
 
 **Kind**: static method of [<code>Util</code>](#Util)  
+**Returns**: <code>string</code> - output of command if hideOutput is true  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -6789,6 +6821,15 @@ helper to convert CSVs into an array. if only one value was given, it's also ret
 | Param | Type | Description |
 | --- | --- | --- |
 | csv | <code>string</code> | potentially comma-separated value or null |
+
+<a name="systemSync"></a>
+
+## systemSync(cmd)
+**Kind**: global function  
+
+| Param |
+| --- |
+| cmd | 
 
 <a name="getUserName"></a>
 

--- a/lib/util/init.git.js
+++ b/lib/util/init.git.js
@@ -167,10 +167,11 @@ const Init = {
                 ]);
             }
             /* eslint-enable unicorn/prefer-ternary */
-
-            responses.gitRemoteUrl = responses.gitRemoteUrl.trim();
-            Util.execSync('git', ['remote', 'add', 'origin', responses.gitRemoteUrl]);
-            return responses.gitRemoteUrl.split('/').pop().split('.')[0];
+            if (typeof responses.gitRemoteUrl === 'string') {
+                responses.gitRemoteUrl = responses.gitRemoteUrl.trim();
+                Util.execSync('git', ['remote', 'add', 'origin', responses.gitRemoteUrl]);
+                return responses.gitRemoteUrl.split('/').pop().split('.')[0];
+            }
         }
     },
     /**

--- a/lib/util/init.git.js
+++ b/lib/util/init.git.js
@@ -258,15 +258,22 @@ const Init = {
 
         for (const file of Object.keys(gitConfigs.values)) {
             if (gitConfigs.values[file]['user.name']) {
-                result['user.name'] = gitConfigs.values[file]['user.name'];
+                // sometimes the config has more than one entry per key - take the last one
+                result['user.name'] = Array.isArray(gitConfigs.values[file]['user.name'])
+                    ? gitConfigs.values[file]['user.name'].pop()
+                    : gitConfigs.values[file]['user.name'];
             }
             if (gitConfigs.values[file]['user.email']) {
-                result['user.email'] = gitConfigs.values[file]['user.email'];
+                // sometimes the config has more than one entry per key - take the last one
+                result['user.email'] = Array.isArray(gitConfigs.values[file]['user.email'])
+                    ? gitConfigs.values[file]['user.email'].pop()
+                    : gitConfigs.values[file]['user.email'];
             }
         }
         if (!result['user.name'] || !result['user.email']) {
             return null;
         }
+
         return result;
     },
 };

--- a/lib/util/init.js
+++ b/lib/util/init.js
@@ -210,10 +210,18 @@ const Init = {
         // set up default deployment market lists
         if (skipInteraction) {
             // don't ask, list all BUs in deployment-target and set deployment-source to ???
-            sourceBuName = '???';
-            Util.logger.info(
-                'Market List "deployment-source" will need to be set up manually. Marking all BUs as target BUs in "deployment-target".'
-            );
+            if (!businessUnits.includes(skipInteraction.developmentBu)) {
+                Util.logger.warn(
+                    `Could not find developmentBu=${skipInteraction.developmentBu} in business units. Skipping.`
+                );
+                delete skipInteraction.developmentBu;
+            }
+            sourceBuName = skipInteraction.developmentBu || '???';
+            if (!skipInteraction.developmentBu) {
+                Util.logger.info(
+                    'Market List "deployment-source" will need to be set up manually. Marking all BUs as target BUs in "deployment-target".'
+                );
+            }
         } else {
             const responses = await inquirer.prompt([
                 {
@@ -231,6 +239,7 @@ const Init = {
 
         // set target list
         for (const bu of businessUnits) {
+            // filter out source BU & parent BU to ensure they dont get deployed to automatically
             if (bu !== sourceBuName && bu !== '_ParentBU_') {
                 properties.marketList['deployment-target'][firstCredentialName + '/' + bu] = bu;
             }

--- a/lib/util/init.js
+++ b/lib/util/init.js
@@ -161,6 +161,9 @@ const Init = {
                 return;
             }
 
+            // set up markets and market lists initially
+            await Init._initMarkets();
+
             // create first commit to backup the project configuration
             if (initGit.status === 'init') {
                 Util.logger.info(`Committing initial setup to Git:`);
@@ -181,6 +184,58 @@ const Init = {
                 'If you use VSCode, please restart it now to install recommended extensions.'
             );
         }
+    },
+
+    /**
+     * helper for @initProject that optionally creates markets and market lists for all BUs
+     */
+    async _initMarkets() {
+        const skipInteraction = Util.skipInteraction;
+        const properties = await config.getProperties(true);
+
+        // get list of business units
+        const firstCredentialName = Object.keys(properties.credentials)[0];
+        const businessUnits = Object.keys(
+            properties.credentials[firstCredentialName].businessUnits
+        );
+
+        // set up empty markets for them
+        const markets = {};
+        for (const bu of businessUnits) {
+            markets[bu] = { suffix: '_' + bu };
+        }
+        properties.markets = markets;
+
+        let sourceBuName;
+        // set up default deployment market lists
+        if (skipInteraction) {
+            // don't ask, list all BUs in deployment-target and set deployment-source to ???
+            sourceBuName = '???';
+            Util.logger.info(
+                'Market List "deployment-source" will need to be set up manually. Marking all BUs as target BUs in "deployment-target".'
+            );
+        } else {
+            const responses = await inquirer.prompt([
+                {
+                    type: 'list',
+                    name: 'developmentBu',
+                    message: 'Please select your development business unit:',
+                    choices: businessUnits.map((bu) => ({ name: bu, value: bu })),
+                },
+            ]);
+            sourceBuName = responses.developmentBu;
+        }
+        // set source list
+        properties.marketList['deployment-source'][firstCredentialName + '/' + sourceBuName] =
+            sourceBuName;
+
+        // set target list
+        for (const bu of businessUnits) {
+            if (bu !== sourceBuName && bu !== '_ParentBU_') {
+                properties.marketList['deployment-target'][firstCredentialName + '/' + bu] = bu;
+            }
+        }
+        await File.saveConfigFile(properties);
     },
     /**
      * helper for {@link Init.initProject}

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -355,16 +355,24 @@ const Util = {
      * @param {string} cmd to be executed command
      * @param {string[]} [args] list of arguments
      * @param {boolean} [hideOutput] if true, output of command will be hidden from CLI
-     * @returns {undefined}
+     * @returns {string} output of command if hideOutput is true
      */
     execSync(cmd, args, hideOutput) {
         args = args || [];
         Util.logger.info('⚡ ' + cmd + ' ' + args.join(' '));
 
-        // the following options ensure the user sees the same output and
-        // interaction options as if the command was manually run
-        const options = hideOutput ? {} : { stdio: [0, 1, 2] };
-        return child_process.execSync(cmd + ' ' + args.join(' '), options);
+        if (hideOutput) {
+            // no output displayed to user but instead returned to parsed elsewhere
+            return child_process
+                .execSync(cmd + ' ' + args.join(' '))
+                .toString()
+                .trim();
+        } else {
+            // the following options ensure the user sees the same output and
+            // interaction options as if the command was manually run
+            child_process.execSync(cmd + ' ' + args.join(' '), { stdio: [0, 1, 2] });
+            return null;
+        }
     },
     /**
      * standardize check to ensure only one result is returned from template search


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request?

- [x] Add something to the core
- closes #554 
- fixes #590 

## What changes did you make? (Give an overview)

when `mcdev init` is executed it now auto-populates `markets` and `marketList` in the config with actual values based on the retrieved list of BUs. We ask the user which BU is the development BU to properly fill deployment-source vs deployment-target lists. Also, we exclude _ParentBU_ in these market lists.
![image](https://user-images.githubusercontent.com/1917227/206415491-cd3217e5-1a46-456d-b92d-f2bb2dc11593.png)


## Is there anything you'd like reviewers to focus on?

1. I decided to auto-fill created markets with ONE variable already, `suffix`, and so far, the value we fill is "underscore + buName". That's a placeholder. 
2. Alternatively, we could have no market variables in the markets or an empty suffix parameter, or we could even ask the user for a list of parameters (comma separated) to refill each market with that list of (empty) parameters.
3. In a CI/CD environment with skipInteraction enabled, one can pass in the name via `--y.developmentBu=myBuName` or leave it empty, which shows a warning and pushes all BUs (except parent) into the target list.
4. If mcdev init is re-run, e.g. to add a 2nd credential, this code is NOT executed. It really only runs upon the initial execution

## Checklist

- [x] I have performed a self-review of my own code
- [x] ran `npm run test` to with 0 tests failing
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ESLint & Prettier are not outputting errors or warnings
