### PR TITLE
#566: cache all subscriber list from ParentBU even when we retrieving list

### DIFF
--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -2905,15 +2905,16 @@ List MetadataType
 **Extends**: [<code>MetadataType</code>](#MetadataType)  
 
 * [List](#List) ⇐ [<code>MetadataType</code>](#MetadataType)
-    * [.retrieve(retrieveDir, [_], [__], [___], [key])](#List.retrieve) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
+    * [.retrieve(retrieveDir, [_], buObject, [___], [key])](#List.retrieve) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
     * [.retrieveForCache(buObject)](#List.retrieveForCache) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
+    * [._retrieveParentAllSubs(buObject, results)](#List._retrieveParentAllSubs) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
     * [.deleteByKey(buObject, customerKey)](#List.deleteByKey) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.postRetrieveTasks(list)](#List.postRetrieveTasks) ⇒ <code>TYPE.MetadataTypeItem</code>
     * [.parseMetadata(metadata, [parseForCache])](#List.parseMetadata) ⇒ <code>TYPE.MetadataTypeItem</code>
 
 <a name="List.retrieve"></a>
 
-### List.retrieve(retrieveDir, [_], [__], [___], [key]) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
+### List.retrieve(retrieveDir, [_], buObject, [___], [key]) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
 Retrieves Metadata of Lists
 
 **Kind**: static method of [<code>List</code>](#List)  
@@ -2923,7 +2924,7 @@ Retrieves Metadata of Lists
 | --- | --- | --- |
 | retrieveDir | <code>string</code> | Directory where retrieved metadata directory will be saved |
 | [_] | <code>void</code> | unused parameter |
-| [__] | <code>void</code> | unused parameter |
+| buObject | <code>TYPE.BuObject</code> | properties for auth |
 | [___] | <code>void</code> | unused parameter |
 | [key] | <code>string</code> | customer key of single item to retrieve |
 
@@ -2938,6 +2939,19 @@ Gets metadata cache with limited fields and does not store value to disk
 | Param | Type | Description |
 | --- | --- | --- |
 | buObject | <code>TYPE.BuObject</code> | properties for auth |
+
+<a name="List._retrieveParentAllSubs"></a>
+
+### List.\_retrieveParentAllSubs(buObject, results) ⇒ <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code>
+helper for @link retrieveForCache and @link retrieve
+
+**Kind**: static method of [<code>List</code>](#List)  
+**Returns**: <code>Promise.&lt;TYPE.MetadataTypeMapObj&gt;</code> - Promise  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| buObject | <code>TYPE.BuObject</code> | properties for auth |
+| results | <code>TYPE.MetadataTypeMapObj</code> | metadata from retrieve for current BU |
 
 <a name="List.deleteByKey"></a>
 

--- a/lib/metadataTypes/List.js
+++ b/lib/metadataTypes/List.js
@@ -18,12 +18,12 @@ class List extends MetadataType {
      *
      * @param {string} retrieveDir Directory where retrieved metadata directory will be saved
      * @param {void} [_] unused parameter
-     * @param {void} [__] unused parameter
+     * @param {TYPE.BuObject} buObject properties for auth
      * @param {void} [___] unused parameter
      * @param {string} [key] customer key of single item to retrieve
      * @returns {Promise.<TYPE.MetadataTypeMapObj>} Promise
      */
-    static retrieve(retrieveDir, _, __, ___, key) {
+    static async retrieve(retrieveDir, _, buObject, ___, key) {
         /** @type {TYPE.SoapRequestParams} */
         let requestParams = null;
         if (key) {
@@ -44,7 +44,8 @@ class List extends MetadataType {
                 },
             };
         }
-        return super.retrieveSOAP(retrieveDir, null, requestParams);
+        const results = await super.retrieveSOAP(retrieveDir, null, requestParams);
+        return await this._retrieveParentAllSubs(buObject, results);
     }
     /**
      * Gets metadata cache with limited fields and does not store value to disk
@@ -53,7 +54,7 @@ class List extends MetadataType {
      * @returns {Promise.<TYPE.MetadataTypeMapObj>} Promise of metadata
      */
     static async retrieveForCache(buObject) {
-        let results = await this.retrieve(null);
+        const results = await this.retrieve(null, null, buObject);
         if (!cache.getCache()?.folder) {
             Util.logger.debug('folders not cached but required for list');
             Util.logger.info(' - Caching dependent Metadata: folder');
@@ -71,6 +72,17 @@ class List extends MetadataType {
         for (const metadataEntry in results.metadata) {
             this.parseMetadata(results.metadata[metadataEntry], true);
         }
+        return await this._retrieveParentAllSubs(buObject, results);
+    }
+
+    /**
+     * helper for @link retrieveForCache and @link retrieve
+     *
+     * @param {TYPE.BuObject} buObject properties for auth
+     * @param {TYPE.MetadataTypeMapObj} results metadata from retrieve for current BU
+     * @returns {Promise.<TYPE.MetadataTypeMapObj>} Promise
+     */
+    static async _retrieveParentAllSubs(buObject, results) {
         if (buObject.eid !== buObject.mid) {
             // for caching, we want to get the All Subscriber List from the Parent Account
             Util.logger.debug(' - Checking MasterUnsubscribeBehavior for current BU');
@@ -108,7 +120,7 @@ class List extends MetadataType {
                 const metadataParentBu = await this.retrieve(
                     null,
                     null,
-                    null,
+                    buObjectParentBu,
                     null,
                     'All Subscribers'
                 );
@@ -125,7 +137,7 @@ class List extends MetadataType {
                 }
 
                 // make sure to overwrite parent bu DEs with local ones
-                results = {
+                return {
                     metadata: { ...metadataParentBu.metadata, ...results.metadata },
                     type: results.type,
                 };

--- a/lib/metadataTypes/List.js
+++ b/lib/metadataTypes/List.js
@@ -72,7 +72,7 @@ class List extends MetadataType {
         for (const metadataEntry in results.metadata) {
             this.parseMetadata(results.metadata[metadataEntry], true);
         }
-        return await this._retrieveParentAllSubs(buObject, results);
+        return results;
     }
 
     /**
@@ -178,18 +178,23 @@ class List extends MetadataType {
      * @returns {TYPE.MetadataTypeItem} Array with one metadata object and one sql string
      */
     static parseMetadata(metadata, parseForCache) {
-        try {
-            metadata.r__folder_Path = cache.searchForField(
-                'folder',
-                metadata.Category,
-                'ID',
-                'Path'
-            );
-            if (!parseForCache) {
-                delete metadata.Category;
+        if (!metadata.r__folder_Path) {
+            // if we cached all subs from parent bu, we don't need to parse the folder path again here
+            try {
+                metadata.r__folder_Path = cache.searchForField(
+                    'folder',
+                    metadata.Category,
+                    'ID',
+                    'Path'
+                );
+                if (!parseForCache) {
+                    delete metadata.Category;
+                }
+            } catch (ex) {
+                Util.logger.warn(
+                    ` - List ${metadata.ID}: '${metadata.CustomerKey}': ${ex.message}`
+                );
             }
-        } catch (ex) {
-            Util.logger.warn(` - List ${metadata.ID}: '${metadata.CustomerKey}': ${ex.message}`);
         }
         return metadata;
     }


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [x] Bugfix
- fixes #566 

## What changes did you make? (Give an overview)

I noticed that the previous PR only covered list being a dependency --> when list was cached only. but it didn't cover the retrieve-all-types situation.


