### PR TITLE
#712 allow setting commit history value for createDeltaPkg via cli + #713: turn createDeltaPkg filter param into option to be able to use it without range

### DIFF
--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -5663,17 +5663,17 @@ DevOps helper class
 **Kind**: global constant  
 
 * [DevOps](#DevOps)
-    * [.getDeltaList(properties, [range], [saveToDeployDir], [filterPaths])](#DevOps.getDeltaList) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
+    * [.getDeltaList(properties, [range], [saveToDeployDir], [filterPaths], [commitHistory])](#DevOps.getDeltaList) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
         * [~delta](#DevOps.getDeltaList..delta) : <code>Array.&lt;TYPE.DeltaPkgItem&gt;</code>
         * [~copied](#DevOps.getDeltaList..copied) : <code>TYPE.DeltaPkgItem</code>
-    * [.buildDeltaDefinitions(properties, range, [diffArr])](#DevOps.buildDeltaDefinitions) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
+    * [.buildDeltaDefinitions(properties, range, [diffArr], [commitHistory])](#DevOps.buildDeltaDefinitions) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
         * [~deltaDeployAll](#DevOps.buildDeltaDefinitions..deltaDeployAll) : <code>Array.&lt;TYPE.DeltaPkgItem&gt;</code>
     * [.document(directory, jsonReport)](#DevOps.document) ⇒ <code>void</code>
     * [.getFilesToCommit(properties, buObject, metadataType, keyArr)](#DevOps.getFilesToCommit) ⇒ <code>Promise.&lt;Array.&lt;string&gt;&gt;</code>
 
 <a name="DevOps.getDeltaList"></a>
 
-### DevOps.getDeltaList(properties, [range], [saveToDeployDir], [filterPaths]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
+### DevOps.getDeltaList(properties, [range], [saveToDeployDir], [filterPaths], [commitHistory]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
 Extracts the delta between a commit and the current state for deployment.
 Interactive commit selection if no commits are passed.
 
@@ -5686,9 +5686,10 @@ Interactive commit selection if no commits are passed.
 | [range] | <code>string</code> | git commit range |
 | [saveToDeployDir] | <code>boolean</code> | if true, copy metadata changes into deploy directory |
 | [filterPaths] | <code>string</code> | filter file paths that start with any specified path (comma separated) |
+| [commitHistory] | <code>number</code> | cli option to override default commit history value in config |
 
 
-* [.getDeltaList(properties, [range], [saveToDeployDir], [filterPaths])](#DevOps.getDeltaList) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
+* [.getDeltaList(properties, [range], [saveToDeployDir], [filterPaths], [commitHistory])](#DevOps.getDeltaList) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
     * [~delta](#DevOps.getDeltaList..delta) : <code>Array.&lt;TYPE.DeltaPkgItem&gt;</code>
     * [~copied](#DevOps.getDeltaList..copied) : <code>TYPE.DeltaPkgItem</code>
 
@@ -5702,7 +5703,7 @@ Interactive commit selection if no commits are passed.
 **Kind**: inner constant of [<code>getDeltaList</code>](#DevOps.getDeltaList)  
 <a name="DevOps.buildDeltaDefinitions"></a>
 
-### DevOps.buildDeltaDefinitions(properties, range, [diffArr]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
+### DevOps.buildDeltaDefinitions(properties, range, [diffArr], [commitHistory]) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
 wrapper around DevOps.getDeltaList, Builder.buildTemplate and M
 
 **Kind**: static method of [<code>DevOps</code>](#DevOps)  
@@ -5713,6 +5714,7 @@ wrapper around DevOps.getDeltaList, Builder.buildTemplate and M
 | properties | <code>TYPE.Mcdevrc</code> | project config file |
 | range | <code>string</code> | git commit range |
 | [diffArr] | <code>Array.&lt;TYPE.DeltaPkgItem&gt;</code> | instead of running git diff the method can also get a list of files to process |
+| [commitHistory] | <code>number</code> | cli option to override default commit history value in config |
 
 <a name="DevOps.buildDeltaDefinitions..deltaDeployAll"></a>
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -308,7 +308,7 @@ yargs
         },
     })
     .command({
-        command: 'createDeltaPkg [range] [filter] [--commitHistory <number>]',
+        command: 'createDeltaPkg [range] [--filter <BU>] [--commitHistory <number>]',
         aliases: ['cdp'],
         desc: 'Copies commit-based file delta into deploy folder',
         builder: (yargs) => {
@@ -317,10 +317,10 @@ yargs
                     type: 'string',
                     describe: 'Pull Request target branch or git commit range',
                 })
-                .positional('filter', {
+                .option('filter', {
                     type: 'string',
                     describe:
-                        'Disable templating & instead filter by the specified file path (comma separated)',
+                        'Disable templating & instead filter by the specified BU path (comma separated), can include subtype, will be prefixed with "retrieve/"',
                 })
                 .option('commitHistory', {
                     type: 'number',

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,9 +61,14 @@ class Mcdev {
 
         return argv.filter
             ? // get source market and source BU from config
-              DevOps.getDeltaList(properties, argv.range, true, argv.filter)
+              DevOps.getDeltaList(properties, argv.range, true, argv.filter, argv.commitHistory)
             : // If no custom filter was provided, use deployment marketLists & templating
-              DevOps.buildDeltaDefinitions(properties, argv.range, argv.diffArr);
+              DevOps.buildDeltaDefinitions(
+                  properties,
+                  argv.range,
+                  argv.diffArr,
+                  argv.commitHistory
+              );
     }
 
     /**

--- a/lib/util/devops.js
+++ b/lib/util/devops.js
@@ -20,9 +20,10 @@ const DevOps = {
      * @param {string} [range] git commit range
      * @param {boolean} [saveToDeployDir] if true, copy metadata changes into deploy directory
      * @param {string} [filterPaths] filter file paths that start with any specified path (comma separated)
+     * @param {number} [commitHistory] cli option to override default commit history value in config
      * @returns {Promise.<TYPE.DeltaPkgItem[]>} -
      */
-    async getDeltaList(properties, range, saveToDeployDir, filterPaths) {
+    async getDeltaList(properties, range, saveToDeployDir, filterPaths, commitHistory) {
         const rangeUserInput = range;
         filterPaths = filterPaths
             ? filterPaths.split(',').map((filePath) =>
@@ -46,7 +47,7 @@ const DevOps = {
             // Current commit is skipped due to no changes
             const commits = await git.log([
                 '--skip=1',
-                `-${properties.options.deployment.commitHistory || 10}`,
+                `-${commitHistory || properties.options.deployment.commitHistory || 10}`,
             ]);
             const display = commits.all.map((commit) => ({
                 name: commit.date + ' / ' + commit.message + ' / ' + commit.author_name,
@@ -253,9 +254,10 @@ const DevOps = {
      * @param {TYPE.Mcdevrc} properties project config file
      * @param {string} range git commit range
      * @param {TYPE.DeltaPkgItem[]} [diffArr] instead of running git diff the method can also get a list of files to process
+     * @param {number} [commitHistory] cli option to override default commit history value in config
      * @returns {Promise.<TYPE.DeltaPkgItem[]>} -
      */
-    async buildDeltaDefinitions(properties, range, diffArr) {
+    async buildDeltaDefinitions(properties, range, diffArr, commitHistory) {
         const skipInteraction = Util.skipInteraction;
         // check if sourceTargetMapping is valid
         if (
@@ -311,7 +313,7 @@ const DevOps = {
 
             const delta = Array.isArray(diffArr)
                 ? diffArr
-                : await DevOps.getDeltaList(properties, range, false, sourceBU);
+                : await DevOps.getDeltaList(properties, range, false, sourceBU, commitHistory);
             // If only chaing templating and buildDefinition if required
             if (!delta || delta.length === 0) {
                 // info/error messages was printed by DevOps.createDeltaPkg() already


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- closes #712 
- closes #713 


## add to docs

```bash
mcdev createDeltaPkg d21b4221..HEAD --filter 'MyProject/BU1'
```

Range and multiple filters (without templating):

```bash
mcdev createDeltaPkg d21b4221..HEAD --filter 'MyProject/BU1,MyProject/BU3'
```

No Range and filter that includes metadata type (without templating):

```bash
mcdev createDeltaPkg --filter 'MyProject/BU1/asset/template'
```


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- n/a test scripts updated
- [ ] Wiki updated (if applicable)
