### PR TITLE
Bugfix/748 asset template can have code in fields that are not extracted yet

### DIFF
--- a/boilerplate/files/.vscode/settings.json
+++ b/boilerplate/files/.vscode/settings.json
@@ -18,6 +18,7 @@
         "*-meta.ssjs": "${capture}-meta.json",
         "*.asset-asset-meta.html": "${dirname}.asset-asset-meta.json",
         "*.asset-message-meta.html": "${dirname}.asset-message-meta.json",
+        "*.asset-template-meta.html": "${dirname}.asset-template-meta.json",
         "*.css": "${capture}.asset-code-meta.json",
         "*.docx": "${capture}.asset-document-meta.json",
         "*.eps": "${capture}.asset-image-meta.json",

--- a/boilerplate/forcedUpdates.json
+++ b/boilerplate/forcedUpdates.json
@@ -1,5 +1,9 @@
 [
     {
+        "version": "4.3.4",
+        "files": [".vscode/settings.json"]
+    },
+    {
         "version": "4.1.12",
         "files": [".vscode/settings.json"]
     },

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -818,16 +818,17 @@ class Asset extends MetadataType {
 
                 // metadata.views.html.content (mandatory)
                 // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
+                const fileName = 'views.html.content' + subtypeExtension;
                 if (
                     (await File.pathExists(
-                        File.normalizePath([...readDirArr, `index${subtypeExtension}.html`])
+                        File.normalizePath([...readDirArr, `${fileName}.html`])
                     )) &&
                     metadata.views.html
                 ) {
                     if (!fileListOnly) {
                         metadata.views.html.content = await File.readFilteredFilename(
                             readDirArr,
-                            'index' + subtypeExtension,
+                            fileName,
                             'html'
                         );
                     }
@@ -836,7 +837,7 @@ class Asset extends MetadataType {
                         // to use this method in templating, store a copy of the info in fileList
                         fileList.push({
                             subFolder: [...subDirArr, customerKey],
-                            fileName: 'index' + subtypeExtension,
+                            fileName: fileName,
                             fileExt: 'html',
                             content: metadata.views.html.content,
                         });
@@ -1178,7 +1179,7 @@ class Asset extends MetadataType {
                 if (metadata.views?.html?.content?.length) {
                     codeArr.push({
                         subFolder: null,
-                        fileName: 'index',
+                        fileName: 'views.html.content',
                         fileExt: 'html',
                         content: metadata.views.html.content,
                     });

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -859,6 +859,61 @@ class Asset extends MetadataType {
                 }
                 break;
             }
+            case 'template': {
+                // template-template
+                // this complex type always creates its own subdir per asset
+                subDirArr = [this.definition.type, subType];
+                readDirArr = [deployDir, ...subDirArr, templateName || customerKey];
+
+                const fileExtArr = ['html']; // eslint-disable-line no-case-declarations
+                for (const ext of fileExtArr) {
+                    if (
+                        await File.pathExists(
+                            File.normalizePath([
+                                ...readDirArr,
+                                `${templateName || customerKey}${subtypeExtension}.${ext}`,
+                            ])
+                        )
+                    ) {
+                        // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
+                        if (!fileListOnly) {
+                            metadata.content = await File.readFilteredFilename(
+                                readDirArr,
+                                (templateName || customerKey) + subtypeExtension,
+                                ext
+                            );
+                        }
+                        if (templateName) {
+                            // to use this method in templating, store a copy of the info in fileList
+                            fileList.push({
+                                subFolder: subDirArr,
+                                fileName: (templateName || customerKey) + subtypeExtension,
+                                fileExt: ext,
+                                content: metadata.content,
+                            });
+                        }
+                        // break loop when found
+                        break;
+                    }
+                }
+
+                // metadata.slots.<>.blocks.<>.content (optional)
+                if (metadata?.slots) {
+                    await this._mergeCode_slots(
+                        'slots',
+                        metadata.slots,
+                        readDirArr,
+                        subtypeExtension,
+                        subDirArr,
+                        fileList,
+                        customerKey,
+                        templateName,
+                        fileListOnly
+                    );
+                }
+
+                break;
+            }
             case 'textonlyemail': {
                 // message
                 // metadata.views.text.content
@@ -970,7 +1025,6 @@ class Asset extends MetadataType {
 
                 break;
             }
-            case 'template': // template-template
             case 'buttonblock': // block - Button Block
             case 'freeformblock': // block
             case 'htmlblock': // block
@@ -1117,9 +1171,9 @@ class Asset extends MetadataType {
         // unfortunately, asset's key can contain spaces at beginning/end which can break the file system when folders are created with it
         const customerKey = metadata.customerKey.trim();
         switch (metadata.assetType.name) {
-            case 'templatebasedemail': // message
+            case 'templatebasedemail': // message-templatebasedemail
             case 'htmlemail': {
-                // message
+                // message-htmlemail
                 // metadata.views.html.content (mandatory)
                 if (metadata.views?.html?.content?.length) {
                     codeArr.push({
@@ -1142,8 +1196,32 @@ class Asset extends MetadataType {
                     subFolder: [customerKey],
                 };
             }
+            case 'template': {
+                // template-template
+                // metadata.content
+                const fileExt = 'html'; // eslint-disable-line no-case-declarations
+                if (metadata?.content?.length) {
+                    codeArr.push({
+                        subFolder: null,
+                        fileName: customerKey,
+                        fileExt: fileExt,
+                        content: metadata.content,
+                    });
+                    delete metadata.content;
+                }
+                // metadata.slots.<>.blocks.<>.content (optional)
+                if (metadata.slots) {
+                    this._extractCode_slots('slots', metadata.slots, codeArr);
+                }
+
+                return {
+                    json: metadata,
+                    codeArr: codeArr,
+                    subFolder: [customerKey],
+                };
+            }
             case 'textonlyemail': {
-                // message
+                // message-textonlyemail
                 // metadata.views.text.content
                 if (metadata.views?.text?.content?.length) {
                     codeArr.push({
@@ -1157,7 +1235,7 @@ class Asset extends MetadataType {
                 return { json: metadata, codeArr: codeArr, subFolder: null };
             }
             case 'webpage': {
-                // asset
+                // asset-webpage
                 // metadata.views.html.content (pre & post 20222)
                 if (metadata.views?.html?.content?.length) {
                     codeArr.push({
@@ -1192,16 +1270,15 @@ class Asset extends MetadataType {
                     subFolder: [customerKey],
                 };
             }
-            case 'template': // template-template
-            case 'buttonblock': // block - Button Block
-            case 'freeformblock': // block
-            case 'htmlblock': // block
-            case 'icemailformblock': // block - Interactive Content Email Form
-            case 'imageblock': // block - Image Block
-            case 'textblock': // block
-            case 'smartcaptureblock': // other
+            case 'buttonblock': // block-buttonblock
+            case 'freeformblock': // block-freeformblock
+            case 'htmlblock': // block-htmlblock
+            case 'icemailformblock': // block-icemailformblock - Interactive Content Email Form
+            case 'imageblock': // block-imageblock - Image Block
+            case 'textblock': // block-textblock
+            case 'smartcaptureblock': // other-smartcaptureblock
             case 'codesnippetblock': {
-                // other
+                // other-codesnippetblock
                 // metadata.content
                 let fileExt = 'html'; // eslint-disable-line no-case-declarations
                 if (

--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -865,22 +865,20 @@ class Asset extends MetadataType {
                 // this complex type always creates its own subdir per asset
                 subDirArr = [this.definition.type, subType];
                 readDirArr = [deployDir, ...subDirArr, templateName || customerKey];
+                const fileName = 'content' + subtypeExtension;
 
                 const fileExtArr = ['html']; // eslint-disable-line no-case-declarations
                 for (const ext of fileExtArr) {
                     if (
                         await File.pathExists(
-                            File.normalizePath([
-                                ...readDirArr,
-                                `${templateName || customerKey}${subtypeExtension}.${ext}`,
-                            ])
+                            File.normalizePath([...readDirArr, `${fileName}.${ext}`])
                         )
                     ) {
                         // the main content can be empty (=not set up yet) hence check if we did extract sth or else readFile() will print error msgs
                         if (!fileListOnly) {
                             metadata.content = await File.readFilteredFilename(
                                 readDirArr,
-                                (templateName || customerKey) + subtypeExtension,
+                                fileName,
                                 ext
                             );
                         }
@@ -888,7 +886,7 @@ class Asset extends MetadataType {
                             // to use this method in templating, store a copy of the info in fileList
                             fileList.push({
                                 subFolder: subDirArr,
-                                fileName: (templateName || customerKey) + subtypeExtension,
+                                fileName: fileName,
                                 fileExt: ext,
                                 content: metadata.content,
                             });
@@ -1204,7 +1202,7 @@ class Asset extends MetadataType {
                 if (metadata?.content?.length) {
                     codeArr.push({
                         subFolder: null,
-                        fileName: customerKey,
+                        fileName: 'content',
                         fileExt: fileExt,
                         content: metadata.content,
                     });


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- fixes #748 
- rename asset-message index...html to  views.html.content...html to align with other subtypes

## Checklist

- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
