### PR TITLE
bugfix/#744: fix "Interaction matching criteria not found. 30003" during journey retrieve

### DIFF
--- a/lib/metadataTypes/Interaction.js
+++ b/lib/metadataTypes/Interaction.js
@@ -97,7 +97,8 @@ class Interaction extends MetadataType {
                           results.items.map(async (a) => {
                               try {
                                   return await this.client.rest.get(
-                                      `${uri}key:${a[this.definition.keyField]}?extras=${extras}`
+                                      `${uri}key:${a[this.definition.keyField]}?extras=${extras}` +
+                                          `&versionNumber=${a.version}`
                                   );
                               } catch (ex) {
                                   // if we do get here, we should log the error and continue instead of failing to download all automations


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- fixes #744 
Without the versionNumber parameter specified, the API returns the most recent version of the journey. If that version is in Deleted it cannot be found and hence the error 30003

