### PR TITLE
#706: fix broken Asset-TriggeredSend link after rename of TSD to TS

### DIFF
--- a/lib/metadataTypes/Asset.js
+++ b/lib/metadataTypes/Asset.js
@@ -509,7 +509,7 @@ class Asset extends MetadataType {
         if (isRefresh) {
             if (createdUpdated.updated) {
                 // only run this if assets were updated. for created assets we do not expect
-                this._refreshTriggeredSendDefinition(metadata);
+                this._refreshTriggeredSend(metadata);
             } else {
                 Util.logger.warn(
                     'You set the --refresh flag but no updated assets found. Skipping refresh of triggeredSendDefinitions.'
@@ -525,7 +525,7 @@ class Asset extends MetadataType {
      * @param {TYPE.MetadataTypeMap} metadata metadata mapped by their keyField
      * @returns {Promise.<void>} -
      */
-    static async _refreshTriggeredSendDefinition(metadata) {
+    static async _refreshTriggeredSend(metadata) {
         // get legacyData.legacyId from assets to compare to TSD's metadata.Email.ID to
         const legacyIdArr = Object.keys(metadata)
             .map((key) => metadata[key]?.legacyData?.legacyId)
@@ -538,13 +538,13 @@ class Asset extends MetadataType {
             return;
         }
         // prep triggeredSendDefinition class
-        const TriggeredSendDefinition = require('./TriggeredSendDefinition');
-        TriggeredSendDefinition.properties = this.properties;
-        TriggeredSendDefinition.buObject = this.buObject;
-        TriggeredSendDefinition.client = this.client;
+        const TriggeredSend = require('./TriggeredSend');
+        TriggeredSend.properties = this.properties;
+        TriggeredSend.buObject = this.buObject;
+        TriggeredSend.client = this.client;
         try {
             // find refreshable TSDs
-            const tsdObj = (await TriggeredSendDefinition.findRefreshableItems()).metadata;
+            const tsdObj = (await TriggeredSend.findRefreshableItems()).metadata;
 
             const tsdCountInitial = Object.keys(tsdObj).length;
             const emailCount = legacyIdArr.length;
@@ -560,9 +560,9 @@ class Asset extends MetadataType {
             );
 
             // get keys of TSDs to refresh
-            const keyArr = await TriggeredSendDefinition.getKeysForValidTSDs(tsdObj);
+            const keyArr = await TriggeredSend.getKeysForValidTSDs(tsdObj);
 
-            await TriggeredSendDefinition.refresh(keyArr);
+            await TriggeredSend.refresh(keyArr);
         } catch {
             Util.logger.warn('Failed to refresh triggeredSendDefinition');
         }


### PR DESCRIPTION
fix what was forgotten in the previous pr for #706 