### PR TITLE
#885: make explainTypes work with folder-subtypes & #884 return list of supported metadata types via --json param

### DIFF
--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -480,7 +480,7 @@ main class
     * [.setOptions(argv)](#Mcdev.setOptions) ⇒ <code>void</code>
     * [.createDeltaPkg(argv)](#Mcdev.createDeltaPkg) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
     * [.selectTypes()](#Mcdev.selectTypes) ⇒ <code>Promise</code>
-    * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>void</code>
+    * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>Array.&lt;string&gt;</code>
     * [.upgrade()](#Mcdev.upgrade) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.retrieve(businessUnit, [selectedTypesArr], [keys], [changelogOnly])](#Mcdev.retrieve) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.deploy(businessUnit, [selectedTypesArr], [keyArr], [fromRetrieve])](#Mcdev.deploy) ⇒ <code>Promise.&lt;Object.&lt;string, TYPE.MultiMetadataTypeMap&gt;&gt;</code>
@@ -555,8 +555,9 @@ handler for 'mcdev createDeltaPkg
 **Returns**: <code>Promise</code> - .  
 <a name="Mcdev.explainTypes"></a>
 
-### Mcdev.explainTypes() ⇒ <code>void</code>
+### Mcdev.explainTypes() ⇒ <code>Array.&lt;string&gt;</code>
 **Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of supported types with their apiNames  
 <a name="Mcdev.upgrade"></a>
 
 ### Mcdev.upgrade() ⇒ <code>Promise.&lt;boolean&gt;</code>
@@ -6166,7 +6167,7 @@ CLI helper class
     * [._askCredentials(properties, [credName])](#Cli._askCredentials) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.selectTypes(properties, [setTypesArr])](#Cli.selectTypes) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._summarizeSubtypes(responses, type)](#Cli._summarizeSubtypes) ⇒ <code>void</code>
-    * [.explainTypes()](#Cli.explainTypes) ⇒ <code>void</code>
+    * [.explainTypes()](#Cli.explainTypes) ⇒ <code>Array.&lt;string&gt;</code>
 
 <a name="Cli.initMcdevConfig"></a>
 
@@ -6298,10 +6299,11 @@ this keeps the config automatically upgradable when we add new subtypes or chang
 
 <a name="Cli.explainTypes"></a>
 
-### Cli.explainTypes() ⇒ <code>void</code>
+### Cli.explainTypes() ⇒ <code>Array.&lt;string&gt;</code>
 shows metadata type descriptions
 
 **Kind**: static method of [<code>Cli</code>](#Cli)  
+**Returns**: <code>Array.&lt;string&gt;</code> - list of supported types with their apiNames  
 <a name="config"></a>
 
 ## config

--- a/docs/dist/documentation.md
+++ b/docs/dist/documentation.md
@@ -480,7 +480,7 @@ main class
     * [.setOptions(argv)](#Mcdev.setOptions) ⇒ <code>void</code>
     * [.createDeltaPkg(argv)](#Mcdev.createDeltaPkg) ⇒ <code>Promise.&lt;Array.&lt;TYPE.DeltaPkgItem&gt;&gt;</code>
     * [.selectTypes()](#Mcdev.selectTypes) ⇒ <code>Promise</code>
-    * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.explainTypes()](#Mcdev.explainTypes) ⇒ <code>Array.&lt;object&gt;</code>
     * [.upgrade()](#Mcdev.upgrade) ⇒ <code>Promise.&lt;boolean&gt;</code>
     * [.retrieve(businessUnit, [selectedTypesArr], [keys], [changelogOnly])](#Mcdev.retrieve) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.deploy(businessUnit, [selectedTypesArr], [keyArr], [fromRetrieve])](#Mcdev.deploy) ⇒ <code>Promise.&lt;Object.&lt;string, TYPE.MultiMetadataTypeMap&gt;&gt;</code>
@@ -555,9 +555,9 @@ handler for 'mcdev createDeltaPkg
 **Returns**: <code>Promise</code> - .  
 <a name="Mcdev.explainTypes"></a>
 
-### Mcdev.explainTypes() ⇒ <code>Array.&lt;string&gt;</code>
+### Mcdev.explainTypes() ⇒ <code>Array.&lt;object&gt;</code>
 **Kind**: static method of [<code>Mcdev</code>](#Mcdev)  
-**Returns**: <code>Array.&lt;string&gt;</code> - list of supported types with their apiNames  
+**Returns**: <code>Array.&lt;object&gt;</code> - list of supported types with their apiNames  
 <a name="Mcdev.upgrade"></a>
 
 ### Mcdev.upgrade() ⇒ <code>Promise.&lt;boolean&gt;</code>
@@ -6167,7 +6167,7 @@ CLI helper class
     * [._askCredentials(properties, [credName])](#Cli._askCredentials) ⇒ <code>Promise.&lt;object&gt;</code>
     * [.selectTypes(properties, [setTypesArr])](#Cli.selectTypes) ⇒ <code>Promise.&lt;void&gt;</code>
     * [._summarizeSubtypes(responses, type)](#Cli._summarizeSubtypes) ⇒ <code>void</code>
-    * [.explainTypes()](#Cli.explainTypes) ⇒ <code>Array.&lt;string&gt;</code>
+    * [.explainTypes()](#Cli.explainTypes) ⇒ <code>Array.&lt;object&gt;</code>
 
 <a name="Cli.initMcdevConfig"></a>
 
@@ -6299,11 +6299,11 @@ this keeps the config automatically upgradable when we add new subtypes or chang
 
 <a name="Cli.explainTypes"></a>
 
-### Cli.explainTypes() ⇒ <code>Array.&lt;string&gt;</code>
+### Cli.explainTypes() ⇒ <code>Array.&lt;object&gt;</code>
 shows metadata type descriptions
 
 **Kind**: static method of [<code>Cli</code>](#Cli)  
-**Returns**: <code>Array.&lt;string&gt;</code> - list of supported types with their apiNames  
+**Returns**: <code>Array.&lt;object&gt;</code> - list of supported types with their apiNames  
 <a name="config"></a>
 
 ## config

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -294,6 +294,12 @@ yargs
         command: 'explainTypes',
         aliases: ['et'],
         desc: 'explains metadata types that can be retrieved',
+        builder: (yargs) => {
+            yargs.option('json', {
+                type: 'boolean',
+                describe: 'optionaly return info in json format',
+            });
+        },
         handler: (argv) => {
             Mcdev.setOptions(argv);
             Mcdev.explainTypes();

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,7 @@ class Mcdev {
             'commitHistory',
             'filter',
             'fromRetrieve',
+            'json',
             'refresh',
             'skipInteraction',
         ];
@@ -115,7 +116,7 @@ class Mcdev {
         await Cli.selectTypes(properties);
     }
     /**
-     * @returns {string[]} list of supported types with their apiNames
+     * @returns {object[]} list of supported types with their apiNames
      */
     static explainTypes() {
         return Cli.explainTypes();

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,10 +115,10 @@ class Mcdev {
         await Cli.selectTypes(properties);
     }
     /**
-     * @returns {void}
+     * @returns {string[]} list of supported types with their apiNames
      */
     static explainTypes() {
-        Cli.explainTypes();
+        return Cli.explainTypes();
     }
     /**
      * @returns {Promise.<boolean>} success flag

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -526,7 +526,7 @@ const Cli = {
     /**
      * shows metadata type descriptions
      *
-     * @returns {void}
+     * @returns {string[]} list of supported types with their apiNames
      */
     explainTypes() {
         // overwrites default layout of console.table
@@ -534,7 +534,7 @@ const Cli = {
 
         const typeChoices = [];
         for (const el in MetadataDefinitions) {
-            if (MetadataDefinitions[el].subTypes) {
+            if (MetadataDefinitions[el].subTypes && MetadataDefinitions[el].extendedSubTypes) {
                 // used for assets to show whats available by default
                 typeChoices.push({
                     Name: MetadataDefinitions[el].typeName,
@@ -545,9 +545,11 @@ const Cli = {
                 for (const subtype of MetadataDefinitions[el].subTypes) {
                     lastCountdown--;
                     const subTypeRetrieveByDefault =
+                        Array.isArray(MetadataDefinitions[el].typeRetrieveByDefault) &&
                         MetadataDefinitions[el].typeRetrieveByDefault.includes(subtype);
+
                     const definition =
-                        '  ' + MetadataDefinitions[el].extendedSubTypes[subtype].join(', ');
+                        '  ' + MetadataDefinitions[el].extendedSubTypes?.[subtype]?.join(', ');
                     typeChoices.push({
                         Name:
                             MetadataDefinitions[el].typeName.replace('-[Subtype]', ': ') + subtype,
@@ -578,6 +580,7 @@ const Cli = {
             return 0;
         });
         console.table(typeChoices); // eslint-disable-line no-console
+        return Object.keys(MetadataDefinitions);
     },
 };
 

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -526,9 +526,25 @@ const Cli = {
     /**
      * shows metadata type descriptions
      *
-     * @returns {string[]} list of supported types with their apiNames
+     * @returns {object[]} list of supported types with their apiNames
      */
     explainTypes() {
+        const json = [];
+        const apiNameArr = Object.keys(MetadataDefinitions);
+
+        for (const apiName of apiNameArr) {
+            const details = MetadataDefinitions[apiName];
+            json.push({
+                name: details.typeName,
+                apiName: details.type,
+                default: details.typeRetrieveByDefault,
+                description: details.typeDescription,
+            });
+        }
+        if (Util.OPTIONS.json) {
+            console.log(json); // eslint-disable-line no-console
+            return json;
+        }
         // overwrites default layout of console.table
         require('console.table');
 
@@ -580,7 +596,7 @@ const Cli = {
             return 0;
         });
         console.table(typeChoices); // eslint-disable-line no-console
-        return Object.keys(MetadataDefinitions);
+        return json;
     },
 };
 

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -530,16 +530,31 @@ const Cli = {
      * @returns {object[]} list of supported types with their apiNames
      */
     explainTypes() {
+        const MetadataTypeInfo = require('./../MetadataTypeInfo');
+        const TransactionalMessage = require('./../metadataTypes/TransactionalMessage');
         const json = [];
         const apiNameArr = Object.keys(MetadataDefinitions);
 
         for (const apiName of apiNameArr) {
             const details = MetadataDefinitions[apiName];
+            const supportCheckClass = apiName.startsWith('transactional')
+                ? TransactionalMessage
+                : MetadataTypeInfo[apiName];
             json.push({
                 name: details.typeName,
                 apiName: details.type,
                 default: details.typeRetrieveByDefault,
                 description: details.typeDescription,
+                supports: {
+                    retrieve: Object.prototype.hasOwnProperty.call(supportCheckClass, 'retrieve'),
+                    create: Object.prototype.hasOwnProperty.call(supportCheckClass, 'create'),
+                    update: Object.prototype.hasOwnProperty.call(supportCheckClass, 'update'),
+                    delete: Object.prototype.hasOwnProperty.call(supportCheckClass, 'deleteByKey'),
+                    retrieveAsTemplate: Object.prototype.hasOwnProperty.call(
+                        supportCheckClass,
+                        'retrieveAsTemplate'
+                    ),
+                },
             });
         }
         if (Util.OPTIONS.json) {

--- a/lib/util/cli.js
+++ b/lib/util/cli.js
@@ -8,6 +8,7 @@ const inquirer = require('inquirer');
 const MetadataDefinitions = require('./../MetadataTypeDefinitions');
 const Util = require('./util');
 const auth = require('./auth');
+require('console.table');
 
 /**
  * CLI helper class
@@ -545,8 +546,6 @@ const Cli = {
             console.log(json); // eslint-disable-line no-console
             return json;
         }
-        // overwrites default layout of console.table
-        require('console.table');
 
         const typeChoices = [];
         for (const el in MetadataDefinitions) {

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -30,15 +30,22 @@ describe('GENERAL', () => {
                 false,
                 'explainTypes --json should not have thrown an error'
             );
+
+            // check if properties are all there
+            expect(typeArr[0]).to.have.all.keys(
+                'name',
+                'apiName',
+                'default',
+                'description',
+                'supports'
+            );
+
             // check if certain types were returned
             assert.equal(
                 typeArr.find((type) => type.apiName === 'dataExtension').apiName,
                 'dataExtension',
                 'Expected to find dataExtension type'
             );
-
-            // check if properties are all there
-            expect(typeArr[0]).to.have.all.keys('name', 'apiName', 'default', 'description');
 
             return;
         });

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -1,0 +1,46 @@
+const chai = require('chai');
+const chaiFiles = require('chai-files');
+const assert = chai.assert;
+const expect = chai.expect;
+chai.use(chaiFiles);
+const testUtils = require('./utils');
+const handler = require('../lib/index');
+
+describe('GENERAL', () => {
+    beforeEach(() => {
+        testUtils.mockSetup();
+    });
+    afterEach(() => {
+        testUtils.mockReset();
+    });
+
+    describe('explainTypes ================', () => {
+        it('without options', () => {
+            handler.explainTypes();
+            assert.equal(!!process.exitCode, false, 'explainTypes should not have thrown an error');
+
+            return;
+        });
+        it('with --json set', () => {
+            handler.setOptions({ json: true });
+            const typeArr = handler.explainTypes();
+
+            assert.equal(
+                !!process.exitCode,
+                false,
+                'explainTypes --json should not have thrown an error'
+            );
+            // check if certain types were returned
+            assert.equal(
+                typeArr.find((type) => type.apiName === 'dataExtension').apiName,
+                'dataExtension',
+                'Expected to find dataExtension type'
+            );
+
+            // check if properties are all there
+            expect(typeArr[0]).to.have.all.keys('name', 'apiName', 'default', 'description');
+
+            return;
+        });
+    });
+});


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #884 
- closes #885 



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] test scripts updated
- [x] Wiki updated (via #722)
