### PR TITLE
Task/914 allow standard GitHub branch names to also update .git/templatemessage

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -3,7 +3,7 @@
 
 # ### git commit message template ###
 git config commit.template .git/templatemessage
-TICKETID=`git rev-parse --abbrev-ref HEAD | LC_ALL=en_US.utf8 grep -oP '((feature|bug|bugfix|fix|hotfix|task|chore)\/)\K\d{1,7}' || true`
+TICKETID=`git rev-parse --abbrev-ref HEAD | LC_ALL=en_US.utf8 grep -oP '((feature|bug|bugfix|fix|hotfix|task|chore)\/)?\K\d{1,7}' || true`
 if [ -z "$TICKETID" ]
 then
   TICKETID="0"

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -3,9 +3,14 @@
 
 # ### git commit message template ###
 git config commit.template .git/templatemessage
-TICKETID=`git rev-parse --abbrev-ref HEAD | LC_ALL=en_US.utf8 grep -oP '((feature|bug|bugfix|fix|hotfix|task|chore)\/)\K\d{1,7}'`
-echo "[POST_CHECKOUT] Setting template commit to $TICKETID"
-echo "#$TICKETID: " > ".git/templatemessage"
+TICKETID=`git rev-parse --abbrev-ref HEAD | LC_ALL=en_US.utf8 grep -oP '((feature|bug|bugfix|fix|hotfix|task|chore)\/)\K\d{1,7}' || true`
+if [ -z "$TICKETID" ]
+then
+  TICKETID="0"
+fi
+TEMPLATE="#$TICKETID: "
+echo "[POST_CHECKOUT] Setting template commit to '$TEMPLATE'"
+echo $TEMPLATE > ".git/templatemessage"
 
 
 # ### run npm install ###


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #914 

also covers main, develop and similar branches. no more hook errors when switching to them

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
