### PR TITLE
bugfix/#893: retrieving mobileKeyword leads to endlessly requesting next batches / bump sfmc-sdk from 1.0.0 to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "prettier": "2.8.8",
                 "prettier-plugin-sql": "0.14.0",
                 "semver": "7.5.0",
-                "sfmc-sdk": "1.0.0",
+                "sfmc-sdk": "1.0.1",
                 "simple-git": "3.18.0",
                 "toposort": "2.0.2",
                 "update-notifier": "5.1.0",
@@ -8719,9 +8719,9 @@
             "dev": true
         },
         "node_modules/sfmc-sdk": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sfmc-sdk/-/sfmc-sdk-1.0.0.tgz",
-            "integrity": "sha512-Okw99BwTXYsTxrt1URYBiWvC8xFGZSn1bB+uO/Z2i/tn/f2CxzsJusrCGmq8IlX/oXJXaYsI1kSulbUrcOtDtg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sfmc-sdk/-/sfmc-sdk-1.0.1.tgz",
+            "integrity": "sha512-0GdDnNa6jqoLGSHf3ByoQNAzlzdGxjSHeH55zFaY9tM4YPtSRgTrsBkZCh5xOBLwr4u7u2X9lbJpxbTWyULhpA==",
             "dependencies": {
                 "axios": "^1.3.5",
                 "fast-xml-parser": "4.2.0",
@@ -16428,9 +16428,9 @@
             "dev": true
         },
         "sfmc-sdk": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sfmc-sdk/-/sfmc-sdk-1.0.0.tgz",
-            "integrity": "sha512-Okw99BwTXYsTxrt1URYBiWvC8xFGZSn1bB+uO/Z2i/tn/f2CxzsJusrCGmq8IlX/oXJXaYsI1kSulbUrcOtDtg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sfmc-sdk/-/sfmc-sdk-1.0.1.tgz",
+            "integrity": "sha512-0GdDnNa6jqoLGSHf3ByoQNAzlzdGxjSHeH55zFaY9tM4YPtSRgTrsBkZCh5xOBLwr4u7u2X9lbJpxbTWyULhpA==",
             "requires": {
                 "axios": "^1.3.5",
                 "fast-xml-parser": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "prettier": "2.8.8",
         "prettier-plugin-sql": "0.14.0",
         "semver": "7.5.0",
-        "sfmc-sdk": "1.0.0",
+        "sfmc-sdk": "1.0.1",
         "simple-git": "3.18.0",
         "toposort": "2.0.2",
         "update-notifier": "5.1.0",


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- fixes #893 


confirmed working with live test data when using https://github.com/DougMidgley/SFMC-SDK/issues/229:
![image](https://github.com/Accenture/sfmc-devtools/assets/1917227/ec997dfd-6042-4aba-b21d-77b38be36308)

