### PR TITLE
bugfix/985: ensure trailing commas in key/type lists do not lead to unforeseen executions

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -471,9 +471,13 @@ function csvToArray(csv) {
     return !csv
         ? null
         : csv.includes(',')
-        ? csv.split(',').map((item) =>
-              // allow whitespace in comma-separated lists
-              item.trim()
-          )
-        : [csv.trim()];
+        ? csv
+              .split(',')
+              .map((item) =>
+                  // allow whitespace in comma-separated lists
+                  item.trim()
+              )
+              // make sure trailing commas are ignored
+              .filter(Boolean)
+        : [csv.trim()].filter(Boolean);
 }


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- fixes #985 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
