### PR TITLE
Task/1041 strip colors from log output for vscode extension

### DIFF
--- a/boilerplate/files/.vscode/extensions.json
+++ b/boilerplate/files/.vscode/extensions.json
@@ -4,6 +4,9 @@
 
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
+        // mcdev vscode extension
+        "IBM.output-colorizer",
+
         // collaboration
         "gruntfuggly.todo-tree",
         "aaron-bond.better-comments",

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -564,6 +564,10 @@ yargs
         type: 'boolean',
         description: 'Only output errors to CLI',
     })
+    .option('noLogColors', {
+        type: 'boolean',
+        description: 'do not use color codes in CLI log output',
+    })
     .option('noLogFile', {
         type: 'boolean',
         description: 'Only output log to CLI but not to files',

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class Mcdev {
             'fromRetrieve',
             'json',
             'like',
+            'noLogColors',
             'noLogFile',
             'refresh',
             'schedule',

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -249,7 +249,9 @@ const Util = {
                 // Write logs to Console
                 level: Util.OPTIONS.loggerLevel || 'info',
                 format: winston.format.combine(
-                    winston.format.colorize(),
+                    Util.OPTIONS.noLogColors
+                        ? winston.format.uncolorize()
+                        : winston.format.colorize(),
                     winston.format.timestamp({ format: 'HH:mm:ss' }),
                     winston.format.simple(),
                     winston.format.printf(


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1041 


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- n/a test scripts updated
- n/a Wiki updated (if applicable)
