### PR TITLE
Bugfix/1097 in the doc md files for `dataExtension`s decimal field type has only precision not scale

### DIFF
--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -1215,7 +1215,11 @@ class DataExtension extends MetadataType {
             for (const element of fieldsJson) {
                 const newJsonElement = {};
                 for (const field of fieldsToKeep) {
-                    newJsonElement[field] = element[field];
+                    if (field === 'MaxLength' && element.FieldType === 'Decimal') {
+                        newJsonElement.MaxLength = `${element.MaxLength},${element.Scale}`;
+                    } else {
+                        newJsonElement[field] = element[field];
+                    }
                 }
                 newJson.push(newJsonElement);
             }

--- a/test/resources/9999999/dataExtension/build-expected.json
+++ b/test/resources/9999999/dataExtension/build-expected.json
@@ -44,6 +44,22 @@
             "IsRequired": true,
             "IsPrimaryKey": true,
             "FieldType": "Text"
+        },
+        {
+            "Name": "decimalField",
+            "DefaultValue": "",
+            "MaxLength": 6,
+            "Scale": 3,
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Decimal"
+        },
+        {
+            "Name": "numberField",
+            "DefaultValue": "",
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Number"
         }
     ],
     "r__folder_ContentType": "dataextension",

--- a/test/resources/9999999/dataExtension/retrieve-expected.json
+++ b/test/resources/9999999/dataExtension/retrieve-expected.json
@@ -44,6 +44,22 @@
             "IsRequired": true,
             "IsPrimaryKey": true,
             "FieldType": "Text"
+        },
+        {
+            "Name": "decimalField",
+            "DefaultValue": "",
+            "MaxLength": 6,
+            "Scale": 3,
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Decimal"
+        },
+        {
+            "Name": "numberField",
+            "DefaultValue": "",
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Number"
         }
     ],
     "r__folder_ContentType": "dataextension",

--- a/test/resources/9999999/dataExtension/retrieve-expected.md
+++ b/test/resources/9999999/dataExtension/retrieve-expected.md
@@ -16,5 +16,5 @@
 | LastName | Text | 50 | - | + |  |
 | EmailAddress | EmailAddress | 254 | - | - |  |
 | ContactKey | Text | 50 | + | - |  |
-| decimalField | Decimal | 6 | - | - |  |
+| decimalField | Decimal | 6,3 | - | - |  |
 | numberField | Number |  | - | - |  |

--- a/test/resources/9999999/dataExtension/retrieve-expected.md
+++ b/test/resources/9999999/dataExtension/retrieve-expected.md
@@ -4,7 +4,7 @@
 
 **Folder:** Data Extensions/
 
-**Fields in table:** 4
+**Fields in table:** 6
 
 **Sendable:** Yes (`ContactKey` to `Subscriber Key`)
 
@@ -16,3 +16,5 @@
 | LastName | Text | 50 | - | + |  |
 | EmailAddress | EmailAddress | 254 | - | - |  |
 | ContactKey | Text | 50 | + | - |  |
+| decimalField | Decimal | 6 | - | - |  |
+| numberField | Number |  | - | - |  |

--- a/test/resources/9999999/dataExtension/template-expected.json
+++ b/test/resources/9999999/dataExtension/template-expected.json
@@ -44,6 +44,22 @@
             "IsRequired": true,
             "IsPrimaryKey": true,
             "FieldType": "Text"
+        },
+        {
+            "Name": "decimalField",
+            "DefaultValue": "",
+            "MaxLength": 6,
+            "Scale": 3,
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Decimal"
+        },
+        {
+            "Name": "numberField",
+            "DefaultValue": "",
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Number"
         }
     ],
     "r__folder_ContentType": "dataextension",

--- a/test/resources/9999999/dataExtension/update-expected.json
+++ b/test/resources/9999999/dataExtension/update-expected.json
@@ -42,6 +42,22 @@
             "FieldType": "Text"
         },
         {
+            "Name": "decimalField",
+            "DefaultValue": "",
+            "MaxLength": 6,
+            "Scale": 3,
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Decimal"
+        },
+        {
+            "Name": "numberField",
+            "DefaultValue": "",
+            "IsPrimaryKey": false,
+            "IsRequired": true,
+            "FieldType": "Number"
+        },
+        {
             "Name": "testField",
             "DefaultValue": "",
             "MaxLength": 254,

--- a/test/resources/9999999/dataExtensionField/retrieve-DataExtension.CustomerKey=testExisting_dataExtension-response.xml
+++ b/test/resources/9999999/dataExtensionField/retrieve-DataExtension.CustomerKey=testExisting_dataExtension-response.xml
@@ -93,6 +93,41 @@
                     <CustomerKey>testExisting_dataExtension</CustomerKey>
                 </DataExtension>
             </Results>
+            <Results xsi:type="DataExtensionField">
+                <PartnerKey xsi:nil="true" />
+                <ObjectID>7b7ef009-4b85-455b-9bdf-b7bef93791d7</ObjectID>
+                <CustomerKey>[testExisting_dataExtension].[numberField]</CustomerKey>
+                <Name>numberField</Name>
+                <Scale>0</Scale>
+                <DefaultValue />
+                <IsRequired>true</IsRequired>
+                <Ordinal>5</Ordinal>
+                <IsPrimaryKey>false</IsPrimaryKey>
+                <FieldType>Number</FieldType>
+                <DataExtension>
+                    <PartnerKey xsi:nil="true" />
+                    <ObjectID xsi:nil="true" />
+                    <CustomerKey>testExisting_dataExtension</CustomerKey>
+                </DataExtension>
+            </Results>
+            <Results xsi:type="DataExtensionField">
+                <PartnerKey xsi:nil="true" />
+                <ObjectID>c5d553cc-2c2a-464d-953d-6901be040f20</ObjectID>
+                <CustomerKey>[testExisting_dataExtension].[decimalField]</CustomerKey>
+                <Name>decimalField</Name>
+                <Scale>3</Scale>
+                <DefaultValue />
+                <MaxLength>6</MaxLength>
+                <IsRequired>true</IsRequired>
+                <Ordinal>4</Ordinal>
+                <IsPrimaryKey>false</IsPrimaryKey>
+                <FieldType>Decimal</FieldType>
+                <DataExtension>
+                    <PartnerKey xsi:nil="true" />
+                    <ObjectID xsi:nil="true" />
+                    <CustomerKey>testExisting_dataExtension</CustomerKey>
+                </DataExtension>
+            </Results>
         </RetrieveResponseMsg>
     </soap:Body>
 </soap:Envelope>

--- a/test/resources/9999999/dataExtensionField/retrieve-response.xml
+++ b/test/resources/9999999/dataExtensionField/retrieve-response.xml
@@ -93,6 +93,41 @@
                     <CustomerKey>testExisting_dataExtension</CustomerKey>
                 </DataExtension>
             </Results>
+            <Results xsi:type="DataExtensionField">
+                <PartnerKey xsi:nil="true" />
+                <ObjectID>7b7ef009-4b85-455b-9bdf-b7bef93791d7</ObjectID>
+                <CustomerKey>[testExisting_dataExtension].[numberField]</CustomerKey>
+                <Name>numberField</Name>
+                <Scale>0</Scale>
+                <DefaultValue />
+                <IsRequired>true</IsRequired>
+                <Ordinal>5</Ordinal>
+                <IsPrimaryKey>false</IsPrimaryKey>
+                <FieldType>Number</FieldType>
+                <DataExtension>
+                    <PartnerKey xsi:nil="true" />
+                    <ObjectID xsi:nil="true" />
+                    <CustomerKey>testExisting_dataExtension</CustomerKey>
+                </DataExtension>
+            </Results>
+            <Results xsi:type="DataExtensionField">
+                <PartnerKey xsi:nil="true" />
+                <ObjectID>c5d553cc-2c2a-464d-953d-6901be040f20</ObjectID>
+                <CustomerKey>[testExisting_dataExtension].[decimalField]</CustomerKey>
+                <Name>decimalField</Name>
+                <Scale>3</Scale>
+                <DefaultValue />
+                <MaxLength>6</MaxLength>
+                <IsRequired>true</IsRequired>
+                <Ordinal>4</Ordinal>
+                <IsPrimaryKey>false</IsPrimaryKey>
+                <FieldType>Decimal</FieldType>
+                <DataExtension>
+                    <PartnerKey xsi:nil="true" />
+                    <ObjectID xsi:nil="true" />
+                    <CustomerKey>testExisting_dataExtension</CustomerKey>
+                </DataExtension>
+            </Results>
         </RetrieveResponseMsg>
     </soap:Body>
 </soap:Envelope>


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1097



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- n/a test scripts updated
- n/a Wiki updated (if applicable)
