### PR TITLE
Bugfix/1133: fix deploying too many dataExtensions blocked by server error

### DIFF
--- a/lib/metadataTypes/DataExtension.js
+++ b/lib/metadataTypes/DataExtension.js
@@ -28,24 +28,14 @@ class DataExtension extends MetadataType {
      */
     static async upsert(metadataMap) {
         // get existing DE-fields for DE-keys in deployment package to properly handle add/update/delete of fields
-        const fieldOptions = {};
-        for (const key of Object.keys(metadataMap)) {
-            fieldOptions.filter = fieldOptions.filter
-                ? {
-                      leftOperand: {
-                          leftOperand: 'DataExtension.CustomerKey',
-                          operator: 'equals',
-                          rightOperand: key,
-                      },
-                      operator: 'OR',
-                      rightOperand: fieldOptions.filter,
-                  }
-                : {
-                      leftOperand: 'DataExtension.CustomerKey',
-                      operator: 'equals',
-                      rightOperand: key,
-                  };
-        }
+        // we need to use IN here because it would fail otherwise if we try to deploy too many DEs at the same time
+        const fieldOptions = {
+            filter: {
+                leftOperand: 'DataExtension.CustomerKey',
+                operator: 'IN',
+                rightOperand: Object.keys(metadataMap),
+            },
+        };
         Util.logger.info(` - Caching dependent Metadata: dataExtensionField`);
         await this.#attachFields(metadataMap, fieldOptions);
 
@@ -868,6 +858,7 @@ class DataExtension extends MetadataType {
     static async #attachFields(metadata, fieldOptions, additionalFields) {
         const fieldsObj = await this._retrieveFields(fieldOptions, additionalFields);
         const fieldKeys = Object.keys(fieldsObj);
+
         // add fields to corresponding DE
         for (const key of fieldKeys) {
             const field = fieldsObj[key];


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1133

## Further details (optional)

This fixes the "Some part of your SQL statement is nested too deeply" server error.

I tested by trying to deploy 1000 dataExtensions at once. didn't work with the old approach. did work with the new IN approach


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
