### PR TITLE
TASK/1289: auto-exclude dataExtension _MobileAddressApplication during retrieve

### DIFF
--- a/lib/metadataTypes/definitions/DataExtension.definition.js
+++ b/lib/metadataTypes/definitions/DataExtension.definition.js
@@ -36,6 +36,7 @@ export default {
             '_ChatMessagingSubscription',
             '_EnterpriseAttribute',
             '_MobileAddress',
+            '_MobileAddressApplication',
             '_MobileLineAddress',
             '_MobileLineAddressContact',
             '_MobileLineProfile',


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1289

## Further details (optional)

...

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [x] Wiki updated (https://github.com/Accenture/sfmc-devtools/pull/1290#issuecomment-2092532148)
