### PR TITLE
Feature/1442 allow specifying multiple values behind --metadata

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,6 +38,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for retrieve:',
                     describe:
@@ -79,6 +80,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for deploy:',
                     describe:
@@ -250,6 +252,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for delete:',
                     describe: 'type or type:key or type:i:id or type:n:name to delete',
@@ -332,6 +335,7 @@ yargs(hideBin(process.argv))
             yargs
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Required parameters for build:',
                     describe: 'type:key combos to build template for',
@@ -424,6 +428,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for buildTemplate:',
                     describe: 'type:key combos to build template for',
@@ -492,6 +497,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for buildDefinition:',
                     describe: 'type:templateName combos to build template for',
@@ -543,6 +549,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for buildDefinitionBulk:',
                     describe: 'type:templateName combos to build template for',
@@ -671,6 +678,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for execute:',
                     describe: 'type or type:key or type:i:id or type:n:name to fix',
@@ -716,6 +724,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for publish:',
                     describe: 'type or type:key or type:i:id or type:n:name to fix',
@@ -761,6 +770,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for schedule:',
                     describe: 'type or type:key or type:i:id or type:n:name to fix',
@@ -800,6 +810,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for pause:',
                     describe: 'type or type:key or type:i:id or type:n:name to fix',
@@ -839,6 +850,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Options for fixKeys:',
                     describe: 'type or type:key or type:i:id or type:n:name to fix',
@@ -902,6 +914,7 @@ yargs(hideBin(process.argv))
                 })
                 .option('metadata', {
                     type: 'string',
+                    array: true,
                     alias: 'm',
                     group: 'Optional parameters for replaceContentBlock:',
                     describe: 'type or type:key or type:i:id or type:n:name to fix',


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1442 

## Further details (optional)

impacts ALL commands that allow using --metadata / -m:
- retrieve
- deploy
- delete
- build
- buildTemplate
- buildDefinition
- buildDefinitionBulk
- execute
- publish
- schedule
- pause
- fixKeys
- replaceContentBlock

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (**TODO**)
