### PR TITLE
Task/1446 disable compact folders in standard vsc config for compatibility with mcdev vsce

### DIFF
--- a/boilerplate/files/.vscode/settings.json
+++ b/boilerplate/files/.vscode/settings.json
@@ -2,6 +2,7 @@
     "workbench.editorAssociations": {
         "*.md": "vscode.markdown.preview.editor"
     },
+    "explorer.compactFolders": false,
     "explorer.fileNesting.enabled": true,
     "explorer.fileNesting.expand": false,
     "explorer.fileNesting.patterns": {

--- a/boilerplate/forcedUpdates.json
+++ b/boilerplate/forcedUpdates.json
@@ -1,5 +1,9 @@
 [
     {
+        "version": "7.1.0",
+        "files": [".vscode/settings.json"]
+    },
+    {
         "version": "7.0.3",
         "files": ["eslint.config.js"],
         "filesRemove": [".eslintignore", ".eslintrc"]


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1446 

## Further details (optional)

while the vscode extension CAN update that itself, it would lead to mcdev upgrade continuously thinking that it needs to overwrite the settings.json... so this is easier

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
