### PR TITLE
Bump sfmc-sdk from 2.1.1 to 2.1.2

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -5,10 +5,6 @@ IFS=$'\n'
 # extract all paths to package-lock.json files
 PACKAGE_LOCK_REGEX="(^package-lock\.json)"
 echo "[POST-MERGE] running git diff --name-only HEAD^1 HEAD"
-echo "[POST-MERGE] 0 $0"
-echo "[POST-MERGE] 1 $1"
-echo "[POST-MERGE] 2 $2"
-echo "[POST-MERGE] 3 $3"
 PACKAGES=$(git diff --name-only HEAD^1 HEAD | grep -E $PACKAGE_LOCK_REGEX || true)
 
 if [[ ${PACKAGES[@]} ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "prettier": "3.3.3",
                 "prettier-plugin-sql": "0.18.1",
                 "semver": "7.6.3",
-                "sfmc-sdk": "2.1.1",
+                "sfmc-sdk": "2.1.2",
                 "simple-git": "3.25.0",
                 "toposort": "2.0.2",
                 "update-notifier": "7.0.0",
@@ -3139,7 +3139,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
             "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -6915,38 +6914,17 @@
             }
         },
         "node_modules/sfmc-sdk": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/sfmc-sdk/-/sfmc-sdk-2.1.1.tgz",
-            "integrity": "sha512-mlkQ+KL4jpiWuRu42s4sB0VJtvJHGpEKG/BCsBY/qN0aUI+Kn2rzrzlQq14dcgosEMbhTBeby2xwSJx48AbwDQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/sfmc-sdk/-/sfmc-sdk-2.1.2.tgz",
+            "integrity": "sha512-kCixm6qvoLrMTKg4lTxlZCDPdpGHX8QhbN9KMoymqGhbAZbZAQGpPfSqsq8549bwJBA3Idini8wFuDAvP+t3sA==",
             "dependencies": {
                 "axios": "^1.7.2",
-                "fast-xml-parser": "4.4.0",
+                "fast-xml-parser": "4.4.1",
                 "p-limit": "5.0.0"
             },
             "engines": {
                 "node": ">=18",
                 "npm": ">=9"
-            }
-        },
-        "node_modules/sfmc-sdk/node_modules/fast-xml-parser": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
-            "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                }
-            ],
-            "dependencies": {
-                "strnum": "^1.0.5"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/sfmc-sdk/node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "prettier": "3.3.3",
         "prettier-plugin-sql": "0.18.1",
         "semver": "7.6.3",
-        "sfmc-sdk": "2.1.1",
+        "sfmc-sdk": "2.1.2",
         "simple-git": "3.25.0",
         "toposort": "2.0.2",
         "update-notifier": "7.0.0",


### PR DESCRIPTION
dependency update that closes a security vulnerability caused by fast-xml-parser 4.4.0