### PR TITLE
task/1721 disable auto-opening markdown renderer to enable vscode's git diff viewer

### DIFF
--- a/boilerplate/files/.vscode/settings.json
+++ b/boilerplate/files/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "workbench.editorAssociations": {
-        "*.md": "vscode.markdown.preview.editor"
-    },
     "explorer.compactFolders": false,
     "explorer.fileNesting.enabled": true,
     "explorer.fileNesting.expand": false,

--- a/boilerplate/forcedUpdates.json
+++ b/boilerplate/forcedUpdates.json
@@ -1,5 +1,9 @@
 [
     {
+        "version": "7.4.2",
+        "files": [".vscode/settings.json"]
+    },
+    {
         "version": "7.4.1",
         "files": [".gitignore"]
     },


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #1721

## Further details (optional)

the diff view only works on text-only views

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
