### PR TITLE
task/2093 no longer auto-recognize vscode extension running mcdev to enable colors in test runs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,9 +229,7 @@ class Mcdev {
         }
         Util.OPTIONS._welcomeMessageShown = true;
 
-        const color = Util.isRunViaVSCodeExtension
-            ? { reset: '', bgWhite: '', fgBlue: '' }
-            : Util.color;
+        const color = Util.color;
         /* eslint-disable no-console */
         if (process.env['USERDNSDOMAIN'] === 'DIR.SVC.ACCENTURE.COM') {
             // Accenture internal message

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -39,9 +39,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Util that contains logger and simple util methods
  */
 export const Util = {
-    isRunViaVSCodeExtension:
-        process.env.VSCODE_AMD_ENTRYPOINT === 'vs/workbench/api/node/extensionHostProcess' || // run via VSCode extension
-        process.env.VSCODE_CRASH_REPORTER_PROCESS_TYPE === 'extensionHost',
     authFileName: '.mcdev-auth.json',
     boilerplateDirectory: '../../boilerplate',
     configFileName: '.mcdevrc.json',
@@ -359,8 +356,8 @@ export const Util = {
         //   debug: 5,
         //   silly: 6
         // }
+
         if (
-            this.isRunViaVSCodeExtension || // run via VSCode extension
             process.env.FORK_PROCESS_ID || // run via Git-Fork
             process.env.PATH.toLowerCase().includes('sourcetree') // run via Atlassian SourceTree
         ) {

--- a/test/resourceFactory.js
+++ b/test/resourceFactory.js
@@ -12,30 +12,7 @@ const projectRoot = projectRootHelper.join(path.sep) + path.sep;
 const parser = new XMLParser();
 const attributeParser = new XMLParser({ ignoreAttributes: false });
 /** @type {typeof Util.color} */
-let color;
-
-/* eslint-disable unicorn/prefer-ternary */
-if (Util.isRunViaVSCodeExtension) {
-    // when we execute the test in a VSCode extension host, we don't want CLI color codes.
-    // @ts-expect-error hacky way to get rid of colors - ts doesn't appreciate the hack
-    color = new Proxy(
-        {},
-        {
-            /**
-             * catch-all for color
-             *
-             * @returns {string} empty string
-             */
-            get() {
-                return '';
-            },
-        }
-    );
-} else {
-    // test is executed directly in a command prompt. Use colors.
-    color = Util.color;
-}
-/* eslint-enable unicorn/prefer-ternary */
+const color = Util.color;
 
 export const tWarn = `${color.bgYellow}${color.fgBlack}TEST-WARNING${color.reset}`;
 export const tError = `${color.bgRed}${color.fgBlack}TEST-ERROR${color.reset}`;


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #2093

## Further details (optional)

...

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
