### PR TITLE
Bug #2361: Null coalesce empty responses

### DIFF
--- a/lib/metadataTypes/Folder.js
+++ b/lib/metadataTypes/Folder.js
@@ -714,7 +714,7 @@ class Folder extends MetadataType {
             ),
             options
         );
-        return response.Results;
+        return response.Results ?? [];
     }
 
     /**

--- a/test/resources/1111111/dataFolder/retrieve-ContentTypeINdataextension,hidden,queryactivity,salesforcedataextension,shared_data,shared_dataextension,shared_salesforcedataextension,synchronizeddataextension-response.xml
+++ b/test/resources/1111111/dataFolder/retrieve-ContentTypeINdataextension,hidden,queryactivity,salesforcedataextension,shared_data,shared_dataextension,shared_salesforcedataextension,synchronizeddataextension-response.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing"
+    xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <soap:Header>
+        <wsa:Action>RetrieveResponse</wsa:Action>
+        <wsa:MessageID>urn:uuid:998a6923-b781-40be-abad-0506f0f97477</wsa:MessageID>
+        <wsa:RelatesTo>urn:uuid:a5d518cc-9bfb-45f1-a4a7-5d11cc1a8d44</wsa:RelatesTo>
+        <wsa:To>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To>
+        <wsse:Security>
+            <wsu:Timestamp wsu:Id="Timestamp-a6c00a2f-fcfa-4882-a72d-8b8983a8cc7e">
+                <wsu:Created>2025-09-05T16:29:03Z</wsu:Created>
+                <wsu:Expires>2025-09-05T16:34:03Z</wsu:Expires>
+            </wsu:Timestamp>
+        </wsse:Security>
+    </soap:Header>
+    <soap:Body>
+        <RetrieveResponseMsg xmlns="http://exacttarget.com/wsdl/partnerAPI">
+            <OverallStatus>OK</OverallStatus>
+            <RequestID>ac40bccd-e8cd-4232-b1ee-e3cfbbfd0b89</RequestID>
+        </RetrieveResponseMsg>
+    </soap:Body>
+</soap:Envelope>

--- a/test/type.dataExtension.test.js
+++ b/test/type.dataExtension.test.js
@@ -91,6 +91,47 @@ describe('type: dataExtension', () => {
             );
             return;
         });
+
+        it('Should not fail if shared dataExtension cannot be retrieved', async () => {
+            // WHEN
+            await handler.retrieve('testInstance/_ParentBU_', ['dataExtension', 'query']);
+            // THEN
+            assert.equal(process.exitCode, 0, 'retrieve should not have thrown an error');
+            // get results from cache
+            const result = cache.getCache();
+            assert.equal(
+                result.dataExtension ? Object.keys(result.dataExtension).length : 0,
+                1,
+                'only one dataExtension expected'
+            );
+            assert.deepEqual(
+                await testUtils.getActualJson(
+                    'testExisting_dataExtensionShared',
+                    'dataExtension',
+                    '_ParentBU_'
+                ),
+                await testUtils.getExpectedJson('1111111', 'dataExtension', 'retrieve'),
+
+                'returned metadata was not equal expected'
+            );
+            // check if MD file was created and equals expectations
+            expect(
+                await testUtils.getActualDoc(
+                    'testExisting_dataExtensionShared',
+                    'dataExtension',
+                    '_ParentBU_'
+                )
+            ).to.equal(
+                await testUtils.getExpectedFile('1111111', 'dataExtension', 'retrieve', 'md')
+            );
+
+            assert.equal(
+                testUtils.getAPIHistoryLength(),
+                7,
+                'Unexpected number of requests made. Run testUtils.logAPIHistoryDebug() to see the requests'
+            );
+            return;
+        });
     });
 
     describe('Deploy ================', () => {


### PR DESCRIPTION
# PR details

There is a possibility during `Folder`'s `retrieve` that there are no results at all (see the issue for example XML). There's an expectation for this to exist, but as it doesn't, the value of the property is `undefined` which leads to an error `Cannot read property 'map' of undefined`

## What changes did you make? (Give an overview)
- Closes issue #2361 
- Add a test case with the expected (empty) response
- Null coalesces `response.Results` in `Folder`'s `retrieve` as it may be `undefined`, and subsequent usage of the value throws an error.

## Further details (optional)

...

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
