### PR TITLE
feature/2432 allow using like-filter searching for underscores

### DIFF
--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -1134,7 +1134,12 @@ export const Util = {
             String.raw`\$1`
         );
         // Replace % and _ with equivalent regex
-        search = search.replaceAll('%', '.*').replaceAll('_', '.');
+        // Replace % with .*
+        search = search.replaceAll('%', '.*');
+        // Replace _ with . only if not surrounded by [ and ]
+        search = search.replaceAll(/(?<!\[)_+(?!\])/g, (match) => '.'.repeat(match.length));
+        // replace [_] with _
+        search = search.replaceAll(String.raw`\[_\]`, '_');
         // Check matches
         return new RegExp('^' + search + '$', 'gi').test(testString);
     },


### PR DESCRIPTION
# PR details

## What changes did you make? (Give an overview)

- closes #2432 

## Further details (optional)

`%_DEV` becomes `%[_]DEV` because the `_` alone is a placeholder by itself but sometimes we want to search an actual underscore in the name/key

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] test scripts updated
- [ ] Wiki updated (if applicable)
