### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close_issues_on_merge.yml
+++ b/.github/workflows/close_issues_on_merge.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   closeIssueOnPrMergeTrigger:
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/Accenture/sfmc-devtools/security/code-scanning/37](https://github.com/Accenture/sfmc-devtools/security/code-scanning/37)

In general, the fix is to define explicit `permissions` for the `GITHUB_TOKEN` so that the workflow does not rely on repository or organization defaults. This is done by adding a `permissions:` block either at the root of the workflow (applying to all jobs) or under the specific job that uses the token. We should grant only the scopes required by the action that closes issues related to merged pull requests.

Specifically for this workflow, `ldez/gha-mjolnir` closes issues that are referenced from merged pull requests. That requires write access to issues and at most read access to pull requests and repository contents. We can therefore add a job-level `permissions` block under `closeIssueOnPrMergeTrigger` that sets:
- `contents: read` (to mirror minimum recommended access),
- `pull-requests: read` (to inspect the merged PR), and
- `issues: write` (to close/update related issues).

No changes to existing steps or environment variables are needed. The only change is to insert the `permissions` mapping just under `closeIssueOnPrMergeTrigger:` and aligned with `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
